### PR TITLE
Lemire/tuning

### DIFF
--- a/benchmarks/bench_protocol.cpp
+++ b/benchmarks/bench_protocol.cpp
@@ -152,7 +152,8 @@ void bench_workload(const std::string &label,
                     const FrozenMap &frozen_map,
                     const KronuzPHF &kronuz_phf,
                     GperfFn gperf_fn,
-                    const BenchFilter &filter) {
+                    const BenchFilter &filter,
+                    bool describe) {
   std::vector<int> results(num_strings, 0);
   std::mt19937_64 gen(42);
   auto shuffle = [&]() {
@@ -171,6 +172,9 @@ void bench_workload(const std::string &label,
     pretty_print(label + " make_perfect_map (" + std::string(phf_map.algorithm_name()) + ")", num_strings,
                  shuffle_bench(phf_fn, shuffle));
     volatile auto sum = std::accumulate(results.begin(), results.end(), 0); // prevent optimization
+    if (describe) {
+      std::println("  {}", phf_map.algorithm_description());
+    }
   }
 
   // naive if/else
@@ -294,6 +298,7 @@ void run_keyset(const std::string &name,
                 const std::vector<std::string_view> &hit_keys,
                 const std::vector<std::string_view> &miss_keys,
                 const BenchFilter &filter,
+                bool describe,
                 size_t num_strings = 200000) {
 
   // Compute MaxKeyLen for display
@@ -319,15 +324,15 @@ void run_keyset(const std::string &name,
 
   if (filter.run_workload("hits")) {
     std::println("  --- all hits ---");
-    bench_workload("hits  ", hits, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter);
+    bench_workload("hits  ", hits, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter, describe);
   }
   if (filter.run_workload("misses")) {
     std::println("  --- all misses ---");
-    bench_workload("misses", misses, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter);
+    bench_workload("misses", misses, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter, describe);
   }
   if (filter.run_workload("mixed")) {
     std::println("  --- mixed (50/50) ---");
-    bench_workload("mixed ", mixed, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter);
+    bench_workload("mixed ", mixed, num_strings, phf_map, naive_fn, uset, frozen_map, kronuz_phf, gperf_fn, filter, describe);
   }
 }
 
@@ -756,6 +761,7 @@ int main(int argc, char *argv[]) {
 
   BenchFilter filter;
   bool verify = false;
+  bool describe = false;
   for (int i = 1; i < argc; i++) {
     std::string arg = argv[i];
     if (arg == "--help" || arg == "-h") {
@@ -763,6 +769,7 @@ int main(int argc, char *argv[]) {
       std::println("Options:");
       std::println("  --filter <tokens>  Comma-separated list of filter tokens");
       std::println("  --verify, -V       Verify all maps return correct results");
+      std::println("  --describe, -D     Print algorithm descriptions");
       std::println("  --help, -h         Show this help message\n");
       std::println("Filter tokens (mix and match):");
       std::println("  Workloads: hits, misses, mixed");
@@ -777,6 +784,9 @@ int main(int argc, char *argv[]) {
     }
     if (arg == "--verify" || arg == "-V") {
       verify = true;
+    }
+    if (arg == "--describe" || arg == "-D") {
+      describe = true;
     }
     if (arg == "--filter" && i + 1 < argc) {
       filter = parse_filter(argv[++i]);
@@ -853,7 +863,7 @@ int main(int argc, char *argv[]) {
     run_keyset("URL Protocols", protocol_phf, protocol_naive, protocol_frozen, protocol_kronuz, gperf_protocol,
       {"http","https","ftp","ws","wss","file"},
       {"ssh","telnet","mailto","data","blob","urn"},
-      filter);
+      filter, describe);
   }
 
   // --- S&P 100 Stock Tickers (100 keys, short) ---
@@ -871,7 +881,7 @@ int main(int argc, char *argv[]) {
        "TSLA","TXN","UNH","UNP","UPS","USB","V","VZ","WFC","WMT"},
       {"RIVN","PLTR","SNAP","UBER","LYFT","COIN","HOOD","DKNG","SOFI","RBLX",
        "ROKU","ZM","ABNB","DASH","CRWD","NET","SNOW","DDOG","MDB","PATH"},
-      filter);
+      filter, describe);
   }
 
   // --- C++ Keywords (15 keys, short-medium) ---
@@ -881,7 +891,7 @@ int main(int argc, char *argv[]) {
        "do","double","else","enum","float","for","goto","if"},
       {"int","void","return","while","switch","struct","static",
        "extern","inline","virtual","public","private","throw","try","catch"},
-      filter);
+      filter, describe);
   }
 
   // --- HTTP Headers (20 keys, long) ---
@@ -894,7 +904,7 @@ int main(int argc, char *argv[]) {
       {"X-Request-Id","Forwarded","Alt-Svc","DNT","Upgrade-Insecure-Requests",
        "X-Frame-Options","Content-Security-Policy","Strict-Transport-Security",
        "Pragma","Warning"},
-      filter);
+      filter, describe);
   }
 
   // --- MIME Types (15 keys, long) ---
@@ -907,6 +917,6 @@ int main(int argc, char *argv[]) {
       {"text/xml","text/csv","application/gzip","application/wasm",
        "image/avif","image/tiff","audio/ogg","video/webm",
        "font/otf","application/x-www-form-urlencoded"},
-      filter);
+      filter, describe);
   }
 }

--- a/include/ConstexprCore/detail/gperf_generator.h
+++ b/include/ConstexprCore/detail/gperf_generator.h
@@ -312,7 +312,7 @@ consteval std::size_t select_positions(
 template <std::size_t N, std::size_t M = N>
 consteval bool try_generate_gperf(
     const std::array<std::string_view, N>& keys,
-    std::array<std::size_t, 256>& asso_values,
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS>& asso_values,
     std::size_t& num_positions,
     std::array<std::size_t, MAX_POSITIONS>& positions,
     std::array<std::size_t, M>& slot_to_key)
@@ -327,24 +327,20 @@ consteval bool try_generate_gperf(
             std::size_t pos = positions[i];
             std::size_t ch = char_at(key, pos);
             if (ch < 256) {
-                h += asso_values[ch];
+                h += asso_values[i][ch];
             }
         }
         return h % M;
     };
 
-    // Pre-compute character frequencies ONCE (not per-collision).
-    // This was previously O(N * positions) per collision — a major bottleneck.
-    std::array<std::size_t, 256> char_freq{};
+    // Pre-compute character frequencies per position ONCE (not per-collision).
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS> char_freq{};
     for (std::size_t k = 0; k < N; ++k) {
         for (std::size_t p = 0; p < num_positions; ++p) {
             std::size_t ch = char_at(keys[k], positions[p]);
-            if (ch < 256) { ++char_freq[ch]; }
+            if (ch < 256) { ++char_freq[p][ch]; }
         }
     }
-    auto char_frequency = [&](std::size_t ch) -> std::size_t {
-        return (ch < 256) ? char_freq[ch] : 0;
-    };
 
     std::size_t jump_values[12];
     std::size_t num_jumps = 0;
@@ -372,7 +368,8 @@ consteval bool try_generate_gperf(
 
     for (std::size_t ji = 0; ji < num_jumps; ++ji) {
         std::size_t jump = jump_values[ji];
-        for (std::size_t i = 0; i < 256; ++i) asso_values[i] = 0;
+        for (std::size_t pi = 0; pi < num_positions; ++pi)
+            for (std::size_t i = 0; i < 256; ++i) asso_values[pi][i] = 0;
 
         bool solved = false;
         for (std::size_t iter = 0; iter < max_iterations; ++iter) {
@@ -398,18 +395,18 @@ consteval bool try_generate_gperf(
                 break;
             }
 
-            std::size_t diff_pos = LAST_CHAR;
+            std::size_t diff_pi = 0;
             for (std::size_t p = 0; p < num_positions; ++p) {
                 std::size_t ca = char_at(keys[col_a], positions[p]);
                 std::size_t cb = char_at(keys[col_b], positions[p]);
                 if (ca != cb && (ca < 256 || cb < 256)) {
-                    diff_pos = positions[p];
+                    diff_pi = p;
                     break;
                 }
             }
 
-            std::size_t ch_a = char_at(keys[col_a], diff_pos);
-            std::size_t ch_b = char_at(keys[col_b], diff_pos);
+            std::size_t ch_a = char_at(keys[col_a], positions[diff_pi]);
+            std::size_t ch_b = char_at(keys[col_b], positions[diff_pi]);
 
             std::size_t bump_char;
             if (ch_a >= 256) {
@@ -417,11 +414,11 @@ consteval bool try_generate_gperf(
             } else if (ch_b >= 256) {
                 bump_char = ch_a;
             } else {
-                bump_char = (char_frequency(ch_a) <= char_frequency(ch_b)) ? ch_a : ch_b;
+                bump_char = (char_freq[diff_pi][ch_a] <= char_freq[diff_pi][ch_b]) ? ch_a : ch_b;
             }
 
             if (bump_char < 256) {
-                asso_values[bump_char] += jump;
+                asso_values[diff_pi][bump_char] += jump;
             }
         }
 
@@ -449,7 +446,7 @@ consteval bool try_generate_gperf(
 template <std::size_t N, std::size_t M = N>
 consteval void generate_gperf(
     const std::array<std::string_view, N>& keys,
-    std::array<std::size_t, 256>& asso_values,
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS>& asso_values,
     std::size_t& num_positions,
     std::array<std::size_t, MAX_POSITIONS>& positions,
     std::array<std::size_t, M>& slot_to_key)
@@ -468,7 +465,7 @@ struct phf_result {
     // to solve (fewer collisions) which dramatically reduces consteval time.
     static constexpr std::size_t MAX_TABLE_SIZE = next_power_of_2(N) * 8;
     std::size_t table_size{};
-    std::array<std::size_t, 256> asso_values{};
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS> asso_values{};
     std::size_t num_positions{};
     std::array<std::size_t, MAX_POSITIONS> positions{};
     std::array<std::size_t, MAX_TABLE_SIZE> slot_to_key{};
@@ -482,7 +479,7 @@ consteval bool try_compute_phf(
 {
     static_assert(M <= phf_result<N>::MAX_TABLE_SIZE, "Table size M exceeds maximum");
 
-    std::array<std::size_t, 256> asso{};
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS> asso{};
     std::size_t npos{};
     std::array<std::size_t, MAX_POSITIONS> pos{};
     std::array<std::size_t, M> s2k{};
@@ -572,7 +569,7 @@ constexpr std::size_t hd_key_hash(std::string_view key) {
 template <std::size_t N, std::size_t M>
 consteval bool try_hash_and_displace(
     const std::array<std::string_view, N>& keys,
-    std::array<std::size_t, 256>& asso_values,
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS>& asso_values,
     std::size_t& num_positions,
     std::array<std::size_t, MAX_POSITIONS>& positions,
     std::array<std::size_t, M>& slot_to_key)
@@ -585,7 +582,7 @@ consteval bool try_hash_and_displace(
     // If num_positions == 0 (lengths alone distinguish), use a simpler path.
     if (num_positions == 0) {
         // Lengths alone distinguish — just assign slots by length % M
-        for (std::size_t i = 0; i < 256; ++i) asso_values[i] = 0;
+        for (std::size_t i = 0; i < 256; ++i) asso_values[0][i] = 0;
         for (std::size_t i = 0; i < M; ++i) slot_to_key[i] = N;
         for (std::size_t i = 0; i < N; ++i) {
             std::size_t slot = keys[i].size() % M;
@@ -598,7 +595,7 @@ consteval bool try_hash_and_displace(
     // Bucket hash: combine first char + last char + length into a byte index.
     // Each unique bucket gets a displacement value stored in asso_values[bucket].
     // Signal H&D mode to compute_hash via num_positions = 0xFF sentinel.
-    for (std::size_t i = 0; i < 256; ++i) asso_values[i] = 0;
+    for (std::size_t i = 0; i < 256; ++i) asso_values[0][i] = 0;
 
     // Use position 0 (first char) and LAST_CHAR (last char) for the bucket hash.
     // These provide the best discrimination for typical key sets (identifiers,
@@ -644,7 +641,7 @@ consteval bool try_hash_and_displace(
 
     // Initialize slots
     for (std::size_t i = 0; i < M; ++i) slot_to_key[i] = N;
-    for (std::size_t i = 0; i < 256; ++i) asso_values[i] = 0;
+    for (std::size_t i = 0; i < 256; ++i) asso_values[0][i] = 0;
 
     // For each bucket (largest first), find a displacement value d such that
     // (base_hash[key] + d) % M lands all keys on empty slots.
@@ -682,7 +679,7 @@ consteval bool try_hash_and_displace(
             }
 
             if (ok) {
-                asso_values[ch] = d;
+                asso_values[0][ch] = d;
                 for (std::size_t k = 0; k < bk_count; ++k) {
                     slot_to_key[bucket_slots[k]] = bucket_keys[k];
                 }
@@ -709,7 +706,7 @@ consteval bool try_compute_phf_hd(
 {
     static_assert(M <= phf_result<N>::MAX_TABLE_SIZE, "Table size M exceeds maximum");
 
-    std::array<std::size_t, 256> asso{};
+    std::array<std::array<std::size_t, 256>, MAX_POSITIONS> asso{};
     std::size_t npos{};
     std::array<std::size_t, MAX_POSITIONS> pos{};
     std::array<std::size_t, M> s2k{};
@@ -753,10 +750,9 @@ consteval phf_result<N> compute_phf_hd_po2(
 template <std::size_t N>
 consteval phf_result<N> compute_phf(const std::array<std::string_view, N>& keys) {
     constexpr std::size_t StartM = next_power_of_2(N);
-    // Threshold: gperf handles N<=15 in ~10s consteval; beyond that its
-    // O(N^2 * iterations) solver exceeds reasonable compile-time budgets.
-    // H&D is O(N) expected and compiles 100 keys in ~1.6 seconds.
-    if constexpr (N <= 15) {
+    // With per-position asso_values, gperf's collision resolver has much
+    // less collateral damage per bump, so it scales to larger key sets.
+    if constexpr (N <= 20) {
         return compute_phf_po2<N, StartM>(keys);
     } else {
         return compute_phf_hd_po2<N, StartM>(keys);

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -49,6 +49,7 @@ struct perfect_hash_set {
     std::array<std::uint8_t, TableSize> slot_key_len_{};                    // key length (0xFF = empty)
     std::array<std::array<char, MaxKeyLen>, TableSize> slot_key_data_{};    // inline key bytes
     std::array<std::uint64_t, TableSize> packed_keys_{};                    // first 8 bytes packed for branchless cmp
+    std::array<std::uint64_t, TableSize> packed_keys2_{};                   // bytes 8-15 packed (MaxKeyLen > 8)
 
     // --- cold data (rarely accessed) ---
     std::array<std::uint8_t, TableSize> slot_to_key_{};     // hash_slot -> declaration-order index
@@ -105,6 +106,11 @@ struct perfect_hash_set {
                     for (std::size_t c = 0; c < k.size() && c < 8; ++c)
                         p |= static_cast<std::uint64_t>(static_cast<unsigned char>(k[c])) << (c * 8);
                     packed_keys_[s] = p;
+                    // Bytes 8-15 packed for branchless two-word comparison.
+                    std::uint64_t p2 = 0;
+                    for (std::size_t c = 8; c < k.size() && c < 16; ++c)
+                        p2 |= static_cast<std::uint64_t>(static_cast<unsigned char>(k[c])) << ((c - 8) * 8);
+                    packed_keys2_[s] = p2;
                 }
             }
         }
@@ -241,6 +247,21 @@ struct perfect_hash_set {
         return v;
     }
 
+    // Pack key bytes 8-15 into a uint64, zero-padded. Branchless.
+    [[nodiscard]] static constexpr std::uint64_t pack_input_upper_(
+        const char* p, std::size_t len) noexcept {
+        std::uint64_t v = 0;
+        if constexpr (MaxKeyLen >= 9)  v |= safe_byte_(p, len, 8);
+        if constexpr (MaxKeyLen >= 10) v |= safe_byte_(p, len, 9)  << 8;
+        if constexpr (MaxKeyLen >= 11) v |= safe_byte_(p, len, 10) << 16;
+        if constexpr (MaxKeyLen >= 12) v |= safe_byte_(p, len, 11) << 24;
+        if constexpr (MaxKeyLen >= 13) v |= safe_byte_(p, len, 12) << 32;
+        if constexpr (MaxKeyLen >= 14) v |= safe_byte_(p, len, 13) << 40;
+        if constexpr (MaxKeyLen >= 15) v |= safe_byte_(p, len, 14) << 48;
+        if constexpr (MaxKeyLen >= 16) v |= safe_byte_(p, len, 15) << 56;
+        return v;
+    }
+
     // Compare key bytes against the stored key at a slot.
     // Three strategies, selected at compile time:
     //
@@ -280,13 +301,10 @@ struct perfect_hash_set {
                 // Slightly more instructions than overlap, but zero branch misses
                 // since safe_byte_ uses conditional arithmetic (no branches).
                 return pack_input_(p, len) == packed_keys_[slot];
-            } else {
+            } else if constexpr (MaxKeyLen <= 16) {
 #ifdef __clang__
-                // MaxKeyLen > 8: first 8 bytes as fast filter, then byte loop.
-                // Key insight: branch on struct-constant min_key_len_ (perfect
-                // prediction) instead of per-key len (data-dependent, mispredicts).
-                //   min_key_len >= 8: ALL keys have 8+ bytes → direct memcpy (1 insn)
-                //   min_key_len <  8: some keys are short → branchless safe_byte (0 BM)
+                // MaxKeyLen 9-16: two packed uint64 words, fully branchless.
+                // Avoids the byte loop that compilers convert to early-exit branches.
                 std::uint64_t input_val;
                 if consteval {
                     input_val = pack_input_(p, len);
@@ -297,8 +315,26 @@ struct perfect_hash_set {
                         input_val = pack_input_(p, len);
                     }
                 }
-                // Branchless: XOR first 8 bytes into diff, then accumulate
-                // remaining bytes. Single check at the end — no intermediate branch.
+                std::uint64_t input_val2 = pack_input_upper_(p, len);
+                std::uint64_t diff = (input_val ^ packed_keys_[slot])
+                                   | (input_val2 ^ packed_keys2_[slot]);
+                return diff == 0;
+#else
+                return std::equal(p, p + len, slot_key_data_[slot].data());
+#endif
+            } else {
+#ifdef __clang__
+                // MaxKeyLen > 16: first 8 bytes packed, then byte loop.
+                std::uint64_t input_val;
+                if consteval {
+                    input_val = pack_input_(p, len);
+                } else {
+                    if (min_key_len_ >= 8) {
+                        __builtin_memcpy(&input_val, p, 8);
+                    } else {
+                        input_val = pack_input_(p, len);
+                    }
+                }
                 const char* a = slot_key_data_[slot].data();
                 std::uint64_t diff = input_val ^ packed_keys_[slot];
                 for (std::size_t i = 8; i < MaxKeyLen; ++i) {
@@ -323,8 +359,8 @@ struct perfect_hash_set {
         // Out-of-range lengths will fail the len_ok check below.
         auto clamped_len = len <= MaxKeyLen ? len : MaxKeyLen;
         std::size_t slot = compute_hash(key);
-        bool len_ok = (slot_key_len_[slot] == static_cast<std::uint8_t>(len));
-        bool key_ok = len == 0 || compare_key_(key.data(), clamped_len, slot);
+        bool len_ok = (slot_key_len_[slot] == len);
+        bool key_ok = compare_key_(key.data(), clamped_len, slot);
         return len_ok & key_ok;
     }
 
@@ -360,10 +396,10 @@ struct perfect_hash_set {
         auto len = key.size();
         auto clamped_len = len <= MaxKeyLen ? len : MaxKeyLen;
         std::size_t slot = compute_hash(key);
-        bool len_ok = (slot_key_len_[slot] == static_cast<std::uint8_t>(len));
-        bool key_ok = len == 0 || compare_key_(key.data(), clamped_len, slot);
-        if (!(len_ok & key_ok)) return std::nullopt;
-        return static_cast<std::size_t>(slot_to_key_[slot]);
+        bool len_ok = (slot_key_len_[slot] == len);
+        bool key_ok = compare_key_(key.data(), clamped_len, slot);
+        volatile auto is_ok = len_ok & key_ok; // prevent compiler optimizing away the check before slot_to_key_ access
+        return is_ok ? std::optional<std::size_t>{slot_to_key_[slot]} : std::nullopt;
     }
 };
 

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -281,31 +281,7 @@ struct perfect_hash_set {
                 // since safe_byte_ uses conditional arithmetic (no branches).
                 return pack_input_(p, len) == packed_keys_[slot];
             } else {
-                // MaxKeyLen > 8: first 8 bytes as fast filter, then byte loop.
-                // Key insight: branch on struct-constant min_key_len_ (perfect
-                // prediction) instead of per-key len (data-dependent, mispredicts).
-                //   min_key_len >= 8: ALL keys have 8+ bytes → direct memcpy (1 insn)
-                //   min_key_len <  8: some keys are short → branchless safe_byte (0 BM)
-                std::uint64_t input_val;
-                if consteval {
-                    input_val = pack_input_(p, len);
-                } else {
-                    if (min_key_len_ >= 8) {
-                        __builtin_memcpy(&input_val, p, 8);
-                    } else {
-                        input_val = pack_input_(p, len);
-                    }
-                }
-                // Branchless: XOR first 8 bytes into diff, then accumulate
-                // remaining bytes. Single check at the end — no intermediate branch.
-                const char* a = slot_key_data_[slot].data();
-                std::uint64_t diff = input_val ^ packed_keys_[slot];
-                for (std::size_t i = 8; i < MaxKeyLen; ++i) {
-                    std::uint64_t a_byte = static_cast<unsigned char>(a[i]);
-                    std::uint64_t p_byte = safe_byte_(p, len, i);
-                    diff |= (a_byte ^ p_byte);
-                }
-                return diff == 0;
+                return std::equal(p, p + len, slot_key_data_[slot].data());
             }
         }
     }

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -281,7 +281,35 @@ struct perfect_hash_set {
                 // since safe_byte_ uses conditional arithmetic (no branches).
                 return pack_input_(p, len) == packed_keys_[slot];
             } else {
+#ifdef __clang__
+                // MaxKeyLen > 8: first 8 bytes as fast filter, then byte loop.
+                // Key insight: branch on struct-constant min_key_len_ (perfect
+                // prediction) instead of per-key len (data-dependent, mispredicts).
+                //   min_key_len >= 8: ALL keys have 8+ bytes → direct memcpy (1 insn)
+                //   min_key_len <  8: some keys are short → branchless safe_byte (0 BM)
+                std::uint64_t input_val;
+                if consteval {
+                    input_val = pack_input_(p, len);
+                } else {
+                    if (min_key_len_ >= 8) {
+                        __builtin_memcpy(&input_val, p, 8);
+                    } else {
+                        input_val = pack_input_(p, len);
+                    }
+                }
+                // Branchless: XOR first 8 bytes into diff, then accumulate
+                // remaining bytes. Single check at the end — no intermediate branch.
+                const char* a = slot_key_data_[slot].data();
+                std::uint64_t diff = input_val ^ packed_keys_[slot];
+                for (std::size_t i = 8; i < MaxKeyLen; ++i) {
+                    std::uint64_t a_byte = static_cast<unsigned char>(a[i]);
+                    std::uint64_t p_byte = safe_byte_(p, len, i);
+                    diff |= (a_byte ^ p_byte);
+                }
+                return diff == 0;
+#else
                 return std::equal(p, p + len, slot_key_data_[slot].data());
+#endif
             }
         }
     }

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -42,7 +42,7 @@ struct perfect_hash_set {
                   "MAX_POSITIONS must be < 0xFF to avoid collision with HD_MODE sentinel");
 
     // --- hot data (accessed every lookup) ---
-    std::array<std::uint8_t, 256> asso_values_{};
+    std::array<std::array<std::uint8_t, 256>, detail::MAX_POSITIONS> asso_values_{};
     std::uint8_t num_positions_{};
     std::array<std::uint8_t, detail::MAX_POSITIONS> positions_{};
     std::uint8_t min_key_len_{};
@@ -117,14 +117,15 @@ struct perfect_hash_set {
                 throw "Key length exceeds MaxKeyLen";
         }
 
-        std::array<std::size_t, 256> full_asso{};
+        std::array<std::array<std::size_t, 256>, detail::MAX_POSITIONS> full_asso{};
         std::size_t wide_num_positions{};
         std::array<std::size_t, detail::MAX_POSITIONS> wide_positions{};
         std::array<std::size_t, TableSize> wide_slot_to_key{};
         detail::generate_gperf<N, TableSize>(keys, full_asso, wide_num_positions, wide_positions, wide_slot_to_key);
 
-        for (std::size_t i = 0; i < 256; ++i)
-            asso_values_[i] = static_cast<std::uint8_t>(full_asso[i] % TableSize);
+        for (std::size_t pi = 0; pi < wide_num_positions; ++pi)
+            for (std::size_t i = 0; i < 256; ++i)
+                asso_values_[pi][i] = static_cast<std::uint8_t>(full_asso[pi][i] % TableSize);
         num_positions_ = static_cast<std::uint8_t>(wide_num_positions);
         for (std::size_t i = 0; i < wide_num_positions; ++i)
             positions_[i] = (wide_positions[i] == detail::LAST_CHAR)
@@ -155,11 +156,14 @@ struct perfect_hash_set {
         // For gperf mode: reduce asso_values mod TableSize (values can be large from bumping).
         // For H&D mode (num_positions == 0xFF): store raw displacement values (already < 255).
         if (data.num_positions == 0xFF) {
+            // H&D mode: only one displacement table in asso_values[0]
             for (std::size_t i = 0; i < 256; ++i)
-                asso_values_[i] = static_cast<std::uint8_t>(data.asso_values[i]);
+                asso_values_[0][i] = static_cast<std::uint8_t>(data.asso_values[0][i]);
         } else {
-            for (std::size_t i = 0; i < 256; ++i)
-                asso_values_[i] = static_cast<std::uint8_t>(data.asso_values[i] % TableSize);
+            // gperf mode: per-position asso tables
+            for (std::size_t pi = 0; pi < data.num_positions; ++pi)
+                for (std::size_t i = 0; i < 256; ++i)
+                    asso_values_[pi][i] = static_cast<std::uint8_t>(data.asso_values[pi][i] % TableSize);
         }
         num_positions_ = static_cast<std::uint8_t>(data.num_positions);
         // Copy positions. For H&D mode (num_positions == 0xFF), only copy
@@ -189,7 +193,24 @@ struct perfect_hash_set {
     [[nodiscard]] constexpr std::string_view algorithm_name() const noexcept {
         return num_positions_ == HD_MODE ? std::string_view("H&D") : std::string_view("gperf");
     }
-
+    [[nodiscard]] constexpr std::string algorithm_description() const noexcept {
+        if (num_positions_ == HD_MODE) {
+            return "Hash-and-Displace: bucket = (key[0] + key[last] + len) & 0xFF; slot = (asso_values[0][bucket] + hd_key_hash(key)) % " + std::to_string(table_size());
+        } else {
+            std::string desc = "gperf: h = len";
+            for (std::uint8_t i = 0; i < num_positions_; ++i) {
+                desc += " + asso_values[" + std::to_string(i) + "][key[";
+                if (positions_[i] == POS_LAST_CHAR) {
+                    desc += "last";
+                } else {
+                    desc += std::to_string(positions_[i]);
+                }
+                desc += "]]";
+            }
+            desc += " % " + std::to_string(table_size());
+            return desc;
+        }
+    }
     [[nodiscard]] constexpr std::string_view key_at(std::size_t i) const noexcept {
         std::uint8_t slot = key_to_slot_[i];
         return std::string_view(slot_key_data_[slot].data(), slot_key_len_[slot]);
@@ -306,7 +327,7 @@ struct perfect_hash_set {
     [[nodiscard]] constexpr constexprcore_really_inline std::size_t compute_hash(std::string_view key) const noexcept {
         if (num_positions_ == HD_MODE) {
             // H&D mode: uses shared hd_bucket_hash + hd_key_hash from generator.
-            std::size_t h = asso_values_[detail::hd_bucket_hash(key)] + detail::hd_key_hash(key);
+            std::size_t h = asso_values_[0][detail::hd_bucket_hash(key)] + detail::hd_key_hash(key);
             if constexpr (TABLE_SIZE_IS_POW2)
                 return h & (TableSize - 1);
             else
@@ -322,7 +343,7 @@ struct perfect_hash_set {
             } else {
                 ch = (pos < key.size()) ? static_cast<unsigned char>(key[pos]) : 256;
             }
-            if (ch < 256) h += asso_values_[ch];
+            if (ch < 256) h += asso_values_[i][ch];
         }
         if constexpr (TABLE_SIZE_IS_POW2)
             return h & (TableSize - 1);
@@ -370,6 +391,10 @@ struct perfect_hash_map {
 
     [[nodiscard]] constexpr std::string_view algorithm_name() const noexcept {
         return set_.algorithm_name();
+    }
+
+    [[nodiscard]] constexpr std::string algorithm_description() const noexcept {
+        return set_.algorithm_description();
     }
 
     [[nodiscard]] constexpr constexprcore_really_inline bool contains(std::string_view key) const noexcept {

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -396,9 +396,9 @@ struct perfect_hash_set {
         auto len = key.size();
         auto clamped_len = len <= MaxKeyLen ? len : MaxKeyLen;
         std::size_t slot = compute_hash(key);
-        bool len_ok = (slot_key_len_[slot] == len);
+        bool len_ok = (slot_key_len_[slot] == len); // can cause branch mispredictions when there are misses.
         bool key_ok = compare_key_(key.data(), clamped_len, slot);
-        volatile auto is_ok = len_ok & key_ok; // prevent compiler optimizing away the check before slot_to_key_ access
+        auto is_ok = len_ok & key_ok;
         return is_ok ? std::optional<std::size_t>{slot_to_key_[slot]} : std::nullopt;
     }
 };


### PR DESCRIPTION

<img width="3569" height="2954" alt="make_perfect_map_hits_comparison" src="https://github.com/user-attachments/assets/b24a3824-6c6b-4d17-86e5-dd70c0335c8d" />

## Terminology



- ns : nanosecond per query
- GV/s : billions of values per second
- c : cycle 
- i : instrucution
- i/c : instructions per cycle
- bm : branch misprediction per value

## With this PR

Linux results with GCC 14 Emerald Rapids


```
$ sudo ./build/benchmarks/bench_protocol  


=== URL Protocols (N=6, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   3.442 ns   0.29 Gv/s  12.02 c  51.00 i  4.24 i/c  0.00 bm
  hits   naive                                     :  10.070 ns   0.10 Gv/s  35.11 c  38.71 i  1.10 i/c  1.03 bm
  hits   std::unordered_map                        :  16.330 ns   0.06 Gv/s  56.96 c  57.14 i  1.00 i/c  1.20 bm
  hits   ankerl::dense                             :  11.015 ns   0.09 Gv/s  38.41 c  87.34 i  2.27 i/c  0.68 bm
  hits   absl::flat_hash_map                       :  11.472 ns   0.09 Gv/s  39.97 c  130.50 i  3.26 i/c  0.50 bm
  hits   frozen::unordered_map                     :  12.636 ns   0.08 Gv/s  44.08 c  84.73 i  1.92 i/c  0.91 bm
  hits   kronuz::phf                               :   7.687 ns   0.13 Gv/s  26.82 c  53.02 i  1.98 i/c  0.69 bm
  hits   gperf                                     :   3.916 ns   0.26 Gv/s  13.65 c  51.36 i  3.76 i/c  0.17 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   3.299 ns   0.30 Gv/s  11.53 c  45.00 i  3.90 i/c  0.00 bm
  misses naive                                     :   8.024 ns   0.12 Gv/s  27.99 c  39.98 i  1.43 i/c  0.68 bm
  misses std::unordered_map                        :  13.401 ns   0.07 Gv/s  46.74 c  73.68 i  1.58 i/c  0.76 bm
  misses ankerl::dense                             :  10.136 ns   0.10 Gv/s  35.29 c  64.00 i  1.81 i/c  0.69 bm
  misses absl::flat_hash_map                       :   7.162 ns   0.14 Gv/s  24.99 c  81.01 i  3.24 i/c  0.34 bm
  misses frozen::unordered_map                     :  13.145 ns   0.08 Gv/s  45.84 c  51.00 i  1.11 i/c  1.20 bm
  misses kronuz::phf                               :   7.409 ns   0.13 Gv/s  25.85 c  52.99 i  2.05 i/c  0.70 bm
  misses gperf                                     :   3.219 ns   0.31 Gv/s  11.25 c  12.67 i  1.13 i/c  0.35 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   8.673 ns   0.12 Gv/s  30.26 c  47.99 i  1.59 i/c  0.50 bm
  mixed  naive                                     :  11.524 ns   0.09 Gv/s  40.19 c  39.34 i  0.98 i/c  1.13 bm
  mixed  std::unordered_map                        :  18.404 ns   0.05 Gv/s  64.18 c  65.42 i  1.02 i/c  1.25 bm
  mixed  ankerl::dense                             :  15.888 ns   0.06 Gv/s  55.41 c  75.63 i  1.37 i/c  1.14 bm
  mixed  absl::flat_hash_map                       :  16.409 ns   0.06 Gv/s  57.22 c  105.67 i  1.85 i/c  0.89 bm
  mixed  frozen::unordered_map                     :  15.850 ns   0.06 Gv/s  55.29 c  67.84 i  1.23 i/c  1.35 bm
  mixed  kronuz::phf                               :  13.158 ns   0.08 Gv/s  45.90 c  53.01 i  1.16 i/c  1.12 bm
  mixed  gperf                                     :   7.297 ns   0.14 Gv/s  25.44 c  31.95 i  1.26 i/c  0.61 bm

=== S&P 100 Tickers (N=100, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :   4.254 ns   0.24 Gv/s  14.86 c  75.00 i  5.05 i/c  0.00 bm
  hits   naive                                     :  64.999 ns   0.02 Gv/s  226.78 c  336.00 i  1.48 i/c  2.92 bm
  hits   std::unordered_map                        :  19.554 ns   0.05 Gv/s  68.17 c  134.30 i  1.97 i/c  0.91 bm
  hits   ankerl::dense                             :  17.418 ns   0.06 Gv/s  60.76 c  95.45 i  1.57 i/c  1.07 bm
  hits   absl::flat_hash_map                       :   9.971 ns   0.10 Gv/s  34.77 c  132.74 i  3.82 i/c  0.30 bm
  hits   frozen::unordered_map                     :  14.430 ns   0.07 Gv/s  50.32 c  83.11 i  1.65 i/c  0.96 bm
  hits   kronuz::phf                               :   6.248 ns   0.16 Gv/s  21.79 c  51.24 i  2.35 i/c  0.51 bm
  hits   gperf                                     :  11.989 ns   0.08 Gv/s  41.79 c  74.49 i  1.78 i/c  0.88 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :   4.017 ns   0.25 Gv/s  14.03 c  69.00 i  4.92 i/c  0.00 bm
  misses naive                                     :  46.628 ns   0.02 Gv/s  162.67 c  305.67 i  1.88 i/c  1.52 bm
  misses std::unordered_map                        :  25.089 ns   0.04 Gv/s  87.53 c  107.69 i  1.23 i/c  0.88 bm
  misses ankerl::dense                             :   5.082 ns   0.20 Gv/s  17.72 c  64.15 i  3.62 i/c  0.20 bm
  misses absl::flat_hash_map                       :   9.616 ns   0.10 Gv/s  33.53 c  84.59 i  2.52 i/c  0.40 bm
  misses frozen::unordered_map                     :  11.940 ns   0.08 Gv/s  41.62 c  53.85 i  1.29 i/c  0.72 bm
  misses kronuz::phf                               :   3.692 ns   0.27 Gv/s  12.90 c  50.80 i  3.94 i/c  0.15 bm
  misses gperf                                     :   3.468 ns   0.29 Gv/s  12.12 c  48.15 i  3.97 i/c  0.15 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :   6.228 ns   0.16 Gv/s  21.72 c  74.01 i  3.41 i/c  0.17 bm
  mixed  naive                                     :  65.656 ns   0.02 Gv/s  228.98 c  330.96 i  1.45 i/c  3.00 bm
  mixed  std::unordered_map                        :  24.431 ns   0.04 Gv/s  85.19 c  129.91 i  1.52 i/c  1.25 bm
  mixed  ankerl::dense                             :  17.861 ns   0.06 Gv/s  62.27 c  90.29 i  1.45 i/c  1.19 bm
  mixed  absl::flat_hash_map                       :  13.112 ns   0.08 Gv/s  45.74 c  124.73 i  2.73 i/c  0.62 bm
  mixed  frozen::unordered_map                     :  16.286 ns   0.06 Gv/s  56.80 c  78.33 i  1.38 i/c  1.20 bm
  mixed  kronuz::phf                               :   9.424 ns   0.11 Gv/s  32.85 c  51.19 i  1.56 i/c  0.76 bm
  mixed  gperf                                     :  13.639 ns   0.07 Gv/s  47.51 c  70.16 i  1.48 i/c  1.05 bm

=== C++ Keywords (N=15, MaxKeyLen=6) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   4.469 ns   0.22 Gv/s  15.61 c  64.00 i  4.10 i/c  0.00 bm
  hits   naive                                     :  24.059 ns   0.04 Gv/s  83.92 c  128.09 i  1.53 i/c  1.65 bm
  hits   std::unordered_map                        :  29.049 ns   0.03 Gv/s  101.33 c  115.02 i  1.14 i/c  1.67 bm
  hits   ankerl::dense                             :  13.976 ns   0.07 Gv/s  48.76 c  89.93 i  1.84 i/c  0.83 bm
  hits   absl::flat_hash_map                       :   8.765 ns   0.11 Gv/s  30.58 c  127.81 i  4.18 i/c  0.21 bm
  hits   frozen::unordered_map                     :  12.759 ns   0.08 Gv/s  44.51 c  89.01 i  2.00 i/c  0.86 bm
  hits   kronuz::phf                               :   7.236 ns   0.14 Gv/s  25.24 c  56.38 i  2.23 i/c  0.64 bm
  hits   gperf                                     :   3.657 ns   0.27 Gv/s  12.78 c  54.66 i  4.28 i/c  0.14 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   4.323 ns   0.23 Gv/s  15.10 c  58.00 i  3.84 i/c  0.00 bm
  misses naive                                     :  14.894 ns   0.07 Gv/s  51.88 c  116.08 i  2.24 i/c  0.69 bm
  misses std::unordered_map                        :  23.596 ns   0.04 Gv/s  82.28 c  131.10 i  1.59 i/c  0.77 bm
  misses ankerl::dense                             :   5.095 ns   0.20 Gv/s  17.76 c  63.87 i  3.60 i/c  0.20 bm
  misses absl::flat_hash_map                       :   7.458 ns   0.13 Gv/s  26.02 c  81.73 i  3.14 i/c  0.27 bm
  misses frozen::unordered_map                     :  15.523 ns   0.06 Gv/s  54.11 c  64.80 i  1.20 i/c  1.21 bm
  misses kronuz::phf                               :   7.115 ns   0.14 Gv/s  24.79 c  59.40 i  2.40 i/c  0.61 bm
  misses gperf                                     :   4.701 ns   0.21 Gv/s  16.42 c  19.97 i  1.22 i/c  0.41 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :  10.819 ns   0.09 Gv/s  37.73 c  61.00 i  1.62 i/c  0.50 bm
  mixed  naive                                     :  21.137 ns   0.05 Gv/s  73.73 c  122.11 i  1.66 i/c  1.32 bm
  mixed  std::unordered_map                        :  29.147 ns   0.03 Gv/s  101.62 c  123.05 i  1.21 i/c  1.40 bm
  mixed  ankerl::dense                             :  13.126 ns   0.08 Gv/s  45.76 c  76.91 i  1.68 i/c  0.74 bm
  mixed  absl::flat_hash_map                       :  15.541 ns   0.06 Gv/s  54.20 c  104.75 i  1.93 i/c  0.69 bm
  mixed  frozen::unordered_map                     :  17.438 ns   0.06 Gv/s  60.82 c  76.93 i  1.26 i/c  1.43 bm
  mixed  kronuz::phf                               :  11.414 ns   0.09 Gv/s  39.80 c  57.92 i  1.46 i/c  1.00 bm
  mixed  gperf                                     :   7.837 ns   0.13 Gv/s  27.31 c  37.32 i  1.37 i/c  0.58 bm

=== HTTP Headers (N=20, MaxKeyLen=15) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   2.270 ns   0.44 Gv/s   7.93 c  43.00 i  5.42 i/c  0.00 bm
  hits   naive                                     :  22.253 ns   0.04 Gv/s  77.49 c  124.95 i  1.61 i/c  1.48 bm
  hits   std::unordered_map                        :  28.736 ns   0.03 Gv/s  100.24 c  102.89 i  1.03 i/c  1.55 bm
  hits   ankerl::dense                             :  17.332 ns   0.06 Gv/s  60.44 c  96.83 i  1.60 i/c  0.88 bm
  hits   absl::flat_hash_map                       :  11.618 ns   0.09 Gv/s  40.50 c  122.45 i  3.02 i/c  0.55 bm
  hits   frozen::unordered_map                     :  21.321 ns   0.05 Gv/s  74.38 c  167.62 i  2.25 i/c  1.29 bm
  hits   kronuz::phf                               :  11.393 ns   0.09 Gv/s  39.71 c  87.69 i  2.21 i/c  0.97 bm
  hits   gperf                                     :   2.868 ns   0.35 Gv/s  10.02 c  53.00 i  5.29 i/c  0.00 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   6.839 ns   0.15 Gv/s  23.86 c  41.80 i  1.75 i/c  0.42 bm
  misses naive                                     :  14.707 ns   0.07 Gv/s  51.19 c  113.94 i  2.23 i/c  0.61 bm
  misses std::unordered_map                        :  22.295 ns   0.04 Gv/s  77.75 c  135.96 i  1.75 i/c  0.78 bm
  misses ankerl::dense                             :   9.365 ns   0.11 Gv/s  32.65 c  71.90 i  2.20 i/c  0.61 bm
  misses absl::flat_hash_map                       :  11.352 ns   0.09 Gv/s  39.56 c  82.69 i  2.09 i/c  0.75 bm
  misses frozen::unordered_map                     :  16.180 ns   0.06 Gv/s  56.45 c  134.32 i  2.38 i/c  1.05 bm
  misses kronuz::phf                               :  12.633 ns   0.08 Gv/s  43.99 c  108.25 i  2.46 i/c  1.08 bm
  misses gperf                                     :   7.415 ns   0.13 Gv/s  25.87 c  17.18 i  0.66 i/c  0.72 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   8.818 ns   0.11 Gv/s  30.73 c  42.60 i  1.39 i/c  0.50 bm
  mixed  naive                                     :  21.801 ns   0.05 Gv/s  76.05 c  121.34 i  1.60 i/c  1.40 bm
  mixed  std::unordered_map                        :  30.936 ns   0.03 Gv/s  107.91 c  113.92 i  1.06 i/c  1.57 bm
  mixed  ankerl::dense                             :  16.817 ns   0.06 Gv/s  58.66 c  88.49 i  1.51 i/c  0.95 bm
  mixed  absl::flat_hash_map                       :  15.216 ns   0.07 Gv/s  53.07 c  109.18 i  2.06 i/c  0.86 bm
  mixed  frozen::unordered_map                     :  21.898 ns   0.05 Gv/s  76.39 c  156.52 i  2.05 i/c  1.47 bm
  mixed  kronuz::phf                               :  15.163 ns   0.07 Gv/s  52.84 c  94.58 i  1.79 i/c  1.31 bm
  mixed  gperf                                     :   6.160 ns   0.16 Gv/s  21.48 c  41.04 i  1.91 i/c  0.34 bm

=== MIME Types (N=15, MaxKeyLen=16) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   2.450 ns   0.41 Gv/s   8.56 c  45.00 i  5.26 i/c  0.00 bm
  hits   naive                                     :  23.391 ns   0.04 Gv/s  81.47 c  123.16 i  1.51 i/c  1.51 bm
  hits   std::unordered_map                        :  27.968 ns   0.04 Gv/s  97.56 c  107.17 i  1.10 i/c  1.56 bm
  hits   ankerl::dense                             :   7.951 ns   0.13 Gv/s  27.74 c  88.20 i  3.18 i/c  0.20 bm
  hits   absl::flat_hash_map                       :   7.551 ns   0.13 Gv/s  26.34 c  124.13 i  4.71 i/c  0.07 bm
  hits   frozen::unordered_map                     :  25.285 ns   0.04 Gv/s  88.20 c  204.42 i  2.32 i/c  1.26 bm
  hits   kronuz::phf                               :  10.931 ns   0.09 Gv/s  38.12 c  97.58 i  2.56 i/c  0.87 bm
  hits   gperf                                     :   5.958 ns   0.17 Gv/s  20.78 c  67.06 i  3.23 i/c  0.31 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   6.097 ns   0.16 Gv/s  21.26 c  43.60 i  2.05 i/c  0.31 bm
  misses naive                                     :  18.042 ns   0.06 Gv/s  62.85 c  127.10 i  2.02 i/c  0.82 bm
  misses std::unordered_map                        :  22.657 ns   0.04 Gv/s  79.02 c  145.43 i  1.84 i/c  0.91 bm
  misses ankerl::dense                             :   4.157 ns   0.24 Gv/s  14.52 c  67.21 i  4.63 i/c  0.10 bm
  misses absl::flat_hash_map                       :   9.731 ns   0.10 Gv/s  33.92 c  83.60 i  2.46 i/c  0.51 bm
  misses frozen::unordered_map                     :  17.240 ns   0.06 Gv/s  60.14 c  111.15 i  1.85 i/c  1.29 bm
  misses kronuz::phf                               :  11.791 ns   0.08 Gv/s  41.11 c  103.75 i  2.52 i/c  0.94 bm
  misses gperf                                     :   8.326 ns   0.12 Gv/s  29.05 c  42.98 i  1.48 i/c  0.61 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :  10.183 ns   0.10 Gv/s  35.51 c  44.44 i  1.25 i/c  0.57 bm
  mixed  naive                                     :  23.854 ns   0.04 Gv/s  83.20 c  124.99 i  1.50 i/c  1.50 bm
  mixed  std::unordered_map                        :  29.705 ns   0.03 Gv/s  103.63 c  122.54 i  1.18 i/c  1.59 bm
  mixed  ankerl::dense                             :  12.885 ns   0.08 Gv/s  44.94 c  79.82 i  1.78 i/c  0.65 bm
  mixed  absl::flat_hash_map                       :  12.530 ns   0.08 Gv/s  43.70 c  107.96 i  2.47 i/c  0.48 bm
  mixed  frozen::unordered_map                     :  26.580 ns   0.04 Gv/s  92.73 c  167.22 i  1.80 i/c  1.69 bm
  mixed  kronuz::phf                               :  16.852 ns   0.06 Gv/s  58.78 c  100.05 i  1.70 i/c  1.33 bm
  mixed  gperf                                     :  10.186 ns   0.10 Gv/s  35.46 c  57.46 i  1.62 i/c  0.69 bm
```


macOS results (Apple clang)

```
> sudo ./build/benchmarks/bench_protocol 

=== URL Protocols (N=6, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   1.159 ns   0.86 Gv/s   5.33 c  45.57 i  8.55 i/c  0.00 bm
  hits   naive                                     :   5.396 ns   0.19 Gv/s  24.38 c  20.26 i  0.83 i/c  1.18 bm
  hits   std::unordered_map                        :   9.737 ns   0.10 Gv/s  43.79 c  115.59 i  2.64 i/c  1.02 bm
  hits   ankerl::dense                             :   9.719 ns   0.10 Gv/s  43.77 c  129.09 i  2.95 i/c  1.02 bm
  hits   absl::flat_hash_map                       :   7.096 ns   0.14 Gv/s  32.12 c  98.57 i  3.07 i/c  0.85 bm
  hits   frozen::unordered_map                     :   6.320 ns   0.16 Gv/s  28.45 c  77.46 i  2.72 i/c  0.88 bm
  hits   kronuz::phf                               :   4.593 ns   0.22 Gv/s  20.77 c  43.58 i  2.10 i/c  0.71 bm
  hits   gperf                                     :   4.363 ns   0.23 Gv/s  19.71 c  66.59 i  3.38 i/c  0.70 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   1.014 ns   0.99 Gv/s   4.61 c  41.32 i  8.96 i/c  0.00 bm
  misses naive                                     :   3.259 ns   0.31 Gv/s  14.73 c  18.41 i  1.25 i/c  0.68 bm
  misses std::unordered_map                        :   3.308 ns   0.30 Gv/s  14.96 c  66.74 i  4.46 i/c  0.35 bm
  misses ankerl::dense                             :   4.634 ns   0.22 Gv/s  20.94 c  103.41 i  4.94 i/c  0.35 bm
  misses absl::flat_hash_map                       :   3.214 ns   0.31 Gv/s  14.58 c  55.74 i  3.82 i/c  0.35 bm
  misses frozen::unordered_map                     :   7.813 ns   0.13 Gv/s  35.34 c  44.07 i  1.25 i/c  1.19 bm
  misses kronuz::phf                               :   4.784 ns   0.21 Gv/s  21.61 c  44.73 i  2.07 i/c  0.68 bm
  misses gperf                                     :   1.947 ns   0.51 Gv/s   8.87 c  13.41 i  1.51 i/c  0.35 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   4.602 ns   0.22 Gv/s  20.79 c  43.44 i  2.09 i/c  0.50 bm
  mixed  naive                                     :   5.239 ns   0.19 Gv/s  23.68 c  19.32 i  0.82 i/c  1.12 bm
  mixed  std::unordered_map                        :  11.344 ns   0.09 Gv/s  50.89 c  91.07 i  1.79 i/c  1.15 bm
  mixed  ankerl::dense                             :  10.722 ns   0.09 Gv/s  48.34 c  116.19 i  2.40 i/c  1.05 bm
  mixed  absl::flat_hash_map                       :   9.995 ns   0.10 Gv/s  45.04 c  77.07 i  1.71 i/c  1.06 bm
  mixed  frozen::unordered_map                     :   8.970 ns   0.11 Gv/s  40.50 c  60.74 i  1.50 i/c  1.31 bm
  mixed  kronuz::phf                               :   8.700 ns   0.11 Gv/s  39.29 c  44.17 i  1.12 i/c  1.15 bm
  mixed  gperf                                     :   5.151 ns   0.19 Gv/s  23.15 c  39.92 i  1.72 i/c  0.88 bm

=== S&P 100 Tickers (N=100, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :   1.822 ns   0.55 Gv/s   8.24 c  63.57 i  7.71 i/c  0.00 bm
  hits   naive                                     :  34.415 ns   0.03 Gv/s  154.52 c  304.76 i  1.97 i/c  2.73 bm
  hits   std::unordered_map                        :   9.904 ns   0.10 Gv/s  44.72 c  120.33 i  2.69 i/c  0.83 bm
  hits   ankerl::dense                             :  14.324 ns   0.07 Gv/s  64.50 c  141.40 i  2.19 i/c  1.30 bm
  hits   absl::flat_hash_map                       :   6.330 ns   0.16 Gv/s  28.60 c  102.17 i  3.57 i/c  0.55 bm
  hits   frozen::unordered_map                     :   7.612 ns   0.13 Gv/s  34.37 c  75.99 i  2.21 i/c  0.95 bm
  hits   kronuz::phf                               :   3.722 ns   0.27 Gv/s  16.88 c  45.27 i  2.68 i/c  0.53 bm
  hits   gperf                                     :   4.775 ns   0.21 Gv/s  21.58 c  74.98 i  3.47 i/c  0.65 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :   1.719 ns   0.58 Gv/s   7.85 c  59.32 i  7.55 i/c  0.00 bm
  misses naive                                     :  24.955 ns   0.04 Gv/s  111.02 c  268.56 i  2.42 i/c  1.41 bm
  misses std::unordered_map                        :   7.688 ns   0.13 Gv/s  34.57 c  75.11 i  2.17 i/c  0.59 bm
  misses ankerl::dense                             :   4.276 ns   0.23 Gv/s  19.21 c  103.67 i  5.40 i/c  0.20 bm
  misses absl::flat_hash_map                       :   8.344 ns   0.12 Gv/s  37.70 c  64.09 i  1.70 i/c  0.73 bm
  misses frozen::unordered_map                     :   7.303 ns   0.14 Gv/s  32.99 c  46.52 i  1.41 i/c  0.72 bm
  misses kronuz::phf                               :   2.329 ns   0.43 Gv/s  10.56 c  46.07 i  4.36 i/c  0.16 bm
  misses gperf                                     :   1.530 ns   0.65 Gv/s   6.94 c  37.32 i  5.38 i/c  0.16 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :   3.364 ns   0.30 Gv/s  15.20 c  62.87 i  4.14 i/c  0.17 bm
  mixed  naive                                     :  35.535 ns   0.03 Gv/s  159.82 c  298.71 i  1.87 i/c  2.88 bm
  mixed  std::unordered_map                        :  11.653 ns   0.09 Gv/s  52.45 c  112.80 i  2.15 i/c  1.08 bm
  mixed  ankerl::dense                             :  14.336 ns   0.07 Gv/s  64.71 c  135.13 i  2.09 i/c  1.39 bm
  mixed  absl::flat_hash_map                       :   8.791 ns   0.11 Gv/s  39.71 c  95.81 i  2.41 i/c  0.90 bm
  mixed  frozen::unordered_map                     :   9.105 ns   0.11 Gv/s  41.14 c  71.17 i  1.73 i/c  1.20 bm
  mixed  kronuz::phf                               :   6.147 ns   0.16 Gv/s  27.79 c  45.44 i  1.64 i/c  0.76 bm
  mixed  gperf                                     :   6.126 ns   0.16 Gv/s  27.68 c  68.80 i  2.49 i/c  0.88 bm

=== C++ Keywords (N=15, MaxKeyLen=6) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   1.442 ns   0.69 Gv/s   6.53 c  57.57 i  8.81 i/c  0.00 bm
  hits   naive                                     :   9.376 ns   0.11 Gv/s  42.23 c  75.53 i  1.79 i/c  1.31 bm
  hits   std::unordered_map                        :   9.521 ns   0.11 Gv/s  42.78 c  112.13 i  2.62 i/c  0.97 bm
  hits   ankerl::dense                             :  11.020 ns   0.09 Gv/s  49.76 c  128.26 i  2.58 i/c  1.06 bm
  hits   absl::flat_hash_map                       :   6.165 ns   0.16 Gv/s  27.50 c  93.93 i  3.42 i/c  0.70 bm
  hits   frozen::unordered_map                     :   6.884 ns   0.15 Gv/s  30.98 c  82.28 i  2.66 i/c  0.84 bm
  hits   kronuz::phf                               :   4.472 ns   0.22 Gv/s  20.00 c  49.41 i  2.47 i/c  0.63 bm
  hits   gperf                                     :   4.672 ns   0.21 Gv/s  21.12 c  72.25 i  3.42 i/c  0.69 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   1.310 ns   0.76 Gv/s   5.95 c  52.32 i  8.79 i/c  0.00 bm
  misses naive                                     :   6.364 ns   0.16 Gv/s  28.74 c  63.91 i  2.22 i/c  0.83 bm
  misses std::unordered_map                        :   6.124 ns   0.16 Gv/s  27.73 c  92.72 i  3.34 i/c  0.34 bm
  misses ankerl::dense                             :   3.576 ns   0.28 Gv/s  16.18 c  103.20 i  6.38 i/c  0.13 bm
  misses absl::flat_hash_map                       :   2.192 ns   0.46 Gv/s   9.92 c  54.73 i  5.52 i/c  0.14 bm
  misses frozen::unordered_map                     :   9.606 ns   0.10 Gv/s  43.37 c  56.94 i  1.31 i/c  1.17 bm
  misses kronuz::phf                               :   4.520 ns   0.22 Gv/s  20.42 c  53.07 i  2.60 i/c  0.55 bm
  misses gperf                                     :   2.730 ns   0.37 Gv/s  12.34 c  19.36 i  1.57 i/c  0.41 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   5.141 ns   0.19 Gv/s  23.15 c  54.95 i  2.37 i/c  0.50 bm
  mixed  naive                                     :   8.858 ns   0.11 Gv/s  39.99 c  69.73 i  1.74 i/c  1.32 bm
  mixed  std::unordered_map                        :  12.775 ns   0.08 Gv/s  57.53 c  102.36 i  1.78 i/c  1.04 bm
  mixed  ankerl::dense                             :  10.370 ns   0.10 Gv/s  46.40 c  115.72 i  2.49 i/c  0.88 bm
  mixed  absl::flat_hash_map                       :   9.523 ns   0.11 Gv/s  42.86 c  74.28 i  1.73 i/c  0.90 bm
  mixed  frozen::unordered_map                     :  10.106 ns   0.10 Gv/s  45.61 c  69.63 i  1.53 i/c  1.36 bm
  mixed  kronuz::phf                               :   7.692 ns   0.13 Gv/s  34.74 c  51.25 i  1.48 i/c  0.98 bm
  mixed  gperf                                     :   5.800 ns   0.17 Gv/s  26.19 c  45.81 i  1.75 i/c  0.86 bm

=== HTTP Headers (N=20, MaxKeyLen=15) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   2.903 ns   0.34 Gv/s  13.14 c  126.07 i  9.60 i/c  0.00 bm
  hits   naive                                     :  11.109 ns   0.09 Gv/s  49.96 c  73.57 i  1.47 i/c  1.92 bm
  hits   std::unordered_map                        :  13.438 ns   0.07 Gv/s  60.52 c  115.57 i  1.91 i/c  1.50 bm
  hits   ankerl::dense                             :  15.907 ns   0.06 Gv/s  71.52 c  141.96 i  1.98 i/c  1.73 bm
  hits   absl::flat_hash_map                       :   8.651 ns   0.12 Gv/s  39.09 c  97.88 i  2.50 i/c  1.23 bm
  hits   frozen::unordered_map                     :  12.916 ns   0.08 Gv/s  58.17 c  157.65 i  2.71 i/c  1.17 bm
  hits   kronuz::phf                               :   6.768 ns   0.15 Gv/s  30.70 c  70.81 i  2.31 i/c  0.92 bm
  hits   gperf                                     :   6.628 ns   0.15 Gv/s  29.94 c  97.58 i  3.26 i/c  0.97 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   4.960 ns   0.20 Gv/s  22.36 c  103.98 i  4.65 i/c  0.43 bm
  misses naive                                     :   6.362 ns   0.16 Gv/s  28.74 c  50.43 i  1.75 i/c  1.02 bm
  misses std::unordered_map                        :  11.008 ns   0.09 Gv/s  49.69 c  96.50 i  1.94 i/c  1.07 bm
  misses ankerl::dense                             :   7.092 ns   0.14 Gv/s  31.89 c  105.87 i  3.32 i/c  0.62 bm
  misses absl::flat_hash_map                       :   6.594 ns   0.15 Gv/s  29.83 c  64.15 i  2.15 i/c  0.86 bm
  misses frozen::unordered_map                     :   9.588 ns   0.10 Gv/s  43.30 c  121.77 i  2.81 i/c  0.82 bm
  misses kronuz::phf                               :   7.818 ns   0.13 Gv/s  35.30 c  89.11 i  2.52 i/c  0.82 bm
  misses gperf                                     :   4.474 ns   0.22 Gv/s  20.21 c  20.04 i  0.99 i/c  0.73 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   4.765 ns   0.21 Gv/s  21.53 c  118.69 i  5.51 i/c  0.34 bm
  mixed  naive                                     :  11.098 ns   0.09 Gv/s  50.10 c  65.89 i  1.32 i/c  2.02 bm
  mixed  std::unordered_map                        :  16.110 ns   0.06 Gv/s  72.29 c  109.22 i  1.51 i/c  1.71 bm
  mixed  ankerl::dense                             :  14.790 ns   0.07 Gv/s  66.11 c  129.90 i  1.96 i/c  1.53 bm
  mixed  absl::flat_hash_map                       :  10.488 ns   0.10 Gv/s  47.44 c  86.74 i  1.83 i/c  1.35 bm
  mixed  frozen::unordered_map                     :  13.533 ns   0.07 Gv/s  60.99 c  145.69 i  2.39 i/c  1.31 bm
  mixed  kronuz::phf                               :   9.564 ns   0.10 Gv/s  43.15 c  76.94 i  1.78 i/c  1.12 bm
  mixed  gperf                                     :   6.731 ns   0.15 Gv/s  30.38 c  71.70 i  2.36 i/c  0.99 bm

=== MIME Types (N=15, MaxKeyLen=16) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   1.878 ns   0.53 Gv/s   8.56 c  80.57 i  9.41 i/c  0.00 bm
  hits   naive                                     :  10.466 ns   0.10 Gv/s  47.25 c  88.32 i  1.87 i/c  1.53 bm
  hits   std::unordered_map                        :   9.275 ns   0.11 Gv/s  40.94 c  117.08 i  2.86 i/c  0.83 bm
  hits   ankerl::dense                             :   8.989 ns   0.11 Gv/s  40.42 c  133.45 i  3.30 i/c  0.83 bm
  hits   absl::flat_hash_map                       :   6.166 ns   0.16 Gv/s  27.70 c  96.87 i  3.50 i/c  0.68 bm
  hits   frozen::unordered_map                     :  15.985 ns   0.06 Gv/s  71.69 c  192.77 i  2.69 i/c  1.15 bm
  hits   kronuz::phf                               :   6.815 ns   0.15 Gv/s  30.79 c  83.72 i  2.72 i/c  0.78 bm
  hits   gperf                                     :   8.510 ns   0.12 Gv/s  38.44 c  132.47 i  3.45 i/c  1.02 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   1.788 ns   0.56 Gv/s   8.11 c  75.32 i  9.29 i/c  0.00 bm
  misses naive                                     :   7.192 ns   0.14 Gv/s  32.42 c  82.19 i  2.53 i/c  0.94 bm
  misses std::unordered_map                        :   8.646 ns   0.12 Gv/s  38.81 c  79.16 i  2.04 i/c  0.73 bm
  misses ankerl::dense                             :   3.397 ns   0.29 Gv/s  15.36 c  104.27 i  6.79 i/c  0.10 bm
  misses absl::flat_hash_map                       :   3.609 ns   0.28 Gv/s  16.32 c  55.69 i  3.41 i/c  0.42 bm
  misses frozen::unordered_map                     :  10.724 ns   0.09 Gv/s  48.37 c  102.33 i  2.12 i/c  1.13 bm
  misses kronuz::phf                               :   7.776 ns   0.13 Gv/s  34.95 c  90.03 i  2.58 i/c  0.83 bm
  misses gperf                                     :   4.323 ns   0.23 Gv/s  19.59 c  39.14 i  2.00 i/c  0.61 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   5.024 ns   0.20 Gv/s  22.70 c  78.48 i  3.46 i/c  0.43 bm
  mixed  naive                                     :  10.616 ns   0.09 Gv/s  47.94 c  86.00 i  1.79 i/c  1.65 bm
  mixed  std::unordered_map                        :  12.354 ns   0.08 Gv/s  55.46 c  102.00 i  1.84 i/c  1.13 bm
  mixed  ankerl::dense                             :  11.466 ns   0.09 Gv/s  51.64 c  121.82 i  2.36 i/c  1.02 bm
  mixed  absl::flat_hash_map                       :   8.149 ns   0.12 Gv/s  36.73 c  80.45 i  2.19 i/c  0.85 bm
  mixed  frozen::unordered_map                     :  17.174 ns   0.06 Gv/s  77.45 c  156.70 i  2.02 i/c  1.51 bm
  mixed  kronuz::phf                               :  11.492 ns   0.09 Gv/s  51.72 c  86.29 i  1.67 i/c  1.14 bm
  mixed  gperf                                     :   8.628 ns   0.12 Gv/s  38.96 c  95.28 i  2.45 i/c  1.12 bm
```



## Our main branch


Linux results with GCC 14.


```

=== URL Protocols (N=6, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   3.441 ns   0.29 Gv/s  12.02 c  50.00 i  4.16 i/c  0.00 bm
  hits   naive                                     :   9.177 ns   0.11 Gv/s  31.99 c  29.50 i  0.92 i/c  1.01 bm
  hits   std::unordered_map                        :  16.942 ns   0.06 Gv/s  59.10 c  57.14 i  0.97 i/c  1.19 bm
  hits   ankerl::dense                             :  11.210 ns   0.09 Gv/s  39.09 c  87.34 i  2.23 i/c  0.68 bm
  hits   absl::flat_hash_map                       :  16.836 ns   0.06 Gv/s  58.70 c  143.57 i  2.45 i/c  0.67 bm
  hits   frozen::unordered_map                     :  12.898 ns   0.08 Gv/s  44.98 c  85.73 i  1.91 i/c  0.88 bm
  hits   kronuz::phf                               :   7.707 ns   0.13 Gv/s  26.89 c  53.02 i  1.97 i/c  0.69 bm
  hits   gperf                                     :   3.918 ns   0.26 Gv/s  13.69 c  51.36 i  3.75 i/c  0.17 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   3.298 ns   0.30 Gv/s  11.52 c  45.00 i  3.91 i/c  0.00 bm
  misses naive                                     :   6.873 ns   0.15 Gv/s  23.97 c  24.00 i  1.00 i/c  0.68 bm
  misses std::unordered_map                        :  14.118 ns   0.07 Gv/s  49.24 c  73.68 i  1.50 i/c  0.74 bm
  misses ankerl::dense                             :  10.138 ns   0.10 Gv/s  35.36 c  64.00 i  1.81 i/c  0.68 bm
  misses absl::flat_hash_map                       :   7.055 ns   0.14 Gv/s  24.58 c  74.01 i  3.01 i/c  0.34 bm
  misses frozen::unordered_map                     :  13.338 ns   0.07 Gv/s  46.51 c  52.00 i  1.12 i/c  1.18 bm
  misses kronuz::phf                               :   7.426 ns   0.13 Gv/s  25.84 c  52.99 i  2.05 i/c  0.70 bm
  misses gperf                                     :   3.197 ns   0.31 Gv/s  11.13 c  12.67 i  1.14 i/c  0.35 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   8.486 ns   0.12 Gv/s  29.60 c  47.49 i  1.60 i/c  0.50 bm
  mixed  naive                                     :   9.884 ns   0.10 Gv/s  34.44 c  26.74 i  0.78 i/c  1.11 bm
  mixed  std::unordered_map                        :  19.154 ns   0.05 Gv/s  66.77 c  65.42 i  0.98 i/c  1.24 bm
  mixed  ankerl::dense                             :  16.096 ns   0.06 Gv/s  56.10 c  75.63 i  1.35 i/c  1.14 bm
  mixed  absl::flat_hash_map                       :  16.426 ns   0.06 Gv/s  57.29 c  100.66 i  1.76 i/c  0.88 bm
  mixed  frozen::unordered_map                     :  16.064 ns   0.06 Gv/s  56.03 c  68.84 i  1.23 i/c  1.33 bm
  mixed  kronuz::phf                               :  13.109 ns   0.08 Gv/s  45.73 c  53.01 i  1.16 i/c  1.14 bm
  mixed  gperf                                     :   7.283 ns   0.14 Gv/s  25.41 c  31.95 i  1.26 i/c  0.61 bm

=== S&P 100 Tickers (N=100, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :   4.256 ns   0.23 Gv/s  14.87 c  75.00 i  5.05 i/c  0.00 bm
  hits   naive                                     :  64.468 ns   0.02 Gv/s  224.78 c  336.00 i  1.49 i/c  2.94 bm
  hits   std::unordered_map                        :  19.296 ns   0.05 Gv/s  67.28 c  132.30 i  1.97 i/c  0.92 bm
  hits   ankerl::dense                             :  17.557 ns   0.06 Gv/s  61.25 c  95.45 i  1.56 i/c  1.07 bm
  hits   absl::flat_hash_map                       :  11.111 ns   0.09 Gv/s  38.75 c  128.75 i  3.32 i/c  0.38 bm
  hits   frozen::unordered_map                     :  14.081 ns   0.07 Gv/s  49.10 c  83.69 i  1.70 i/c  0.98 bm
  hits   kronuz::phf                               :   6.265 ns   0.16 Gv/s  21.85 c  51.24 i  2.34 i/c  0.52 bm
  hits   gperf                                     :  12.376 ns   0.08 Gv/s  43.17 c  74.72 i  1.73 i/c  0.95 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :   4.015 ns   0.25 Gv/s  14.02 c  69.00 i  4.92 i/c  0.00 bm
  misses naive                                     :  45.912 ns   0.02 Gv/s  160.13 c  305.67 i  1.91 i/c  1.52 bm
  misses std::unordered_map                        :  24.897 ns   0.04 Gv/s  86.85 c  106.29 i  1.22 i/c  0.87 bm
  misses ankerl::dense                             :   5.121 ns   0.20 Gv/s  17.86 c  64.15 i  3.59 i/c  0.20 bm
  misses absl::flat_hash_map                       :  12.061 ns   0.08 Gv/s  42.07 c  80.92 i  1.92 i/c  0.56 bm
  misses frozen::unordered_map                     :  11.985 ns   0.08 Gv/s  41.78 c  54.00 i  1.29 i/c  0.73 bm
  misses kronuz::phf                               :   3.651 ns   0.27 Gv/s  12.75 c  50.80 i  3.98 i/c  0.15 bm
  misses gperf                                     :   3.488 ns   0.29 Gv/s  12.18 c  48.15 i  3.95 i/c  0.15 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :   6.039 ns   0.17 Gv/s  21.06 c  74.01 i  3.51 i/c  0.17 bm
  mixed  naive                                     :  65.836 ns   0.02 Gv/s  229.67 c  330.96 i  1.44 i/c  3.05 bm
  mixed  std::unordered_map                        :  23.978 ns   0.04 Gv/s  83.63 c  128.01 i  1.53 i/c  1.25 bm
  mixed  ankerl::dense                             :  18.058 ns   0.06 Gv/s  62.99 c  90.29 i  1.43 i/c  1.19 bm
  mixed  absl::flat_hash_map                       :  14.621 ns   0.07 Gv/s  50.94 c  120.74 i  2.37 i/c  0.75 bm
  mixed  frozen::unordered_map                     :  15.859 ns   0.06 Gv/s  55.25 c  78.83 i  1.43 i/c  1.21 bm
  mixed  kronuz::phf                               :   9.405 ns   0.11 Gv/s  32.79 c  51.19 i  1.56 i/c  0.76 bm
  mixed  gperf                                     :  13.808 ns   0.07 Gv/s  48.18 c  70.35 i  1.46 i/c  1.11 bm

=== C++ Keywords (N=15, MaxKeyLen=6) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   4.459 ns   0.22 Gv/s  15.58 c  63.00 i  4.04 i/c  0.00 bm
  hits   naive                                     :  18.449 ns   0.05 Gv/s  64.35 c  81.33 i  1.26 i/c  1.64 bm
  hits   std::unordered_map                        :  29.823 ns   0.03 Gv/s  104.02 c  115.02 i  1.11 i/c  1.65 bm
  hits   ankerl::dense                             :  14.096 ns   0.07 Gv/s  49.09 c  89.93 i  1.83 i/c  0.84 bm
  hits   absl::flat_hash_map                       :   8.661 ns   0.12 Gv/s  30.19 c  120.81 i  4.00 i/c  0.21 bm
  hits   frozen::unordered_map                     :  13.526 ns   0.07 Gv/s  47.14 c  90.54 i  1.92 i/c  0.84 bm
  hits   kronuz::phf                               :   7.318 ns   0.14 Gv/s  25.53 c  56.38 i  2.21 i/c  0.62 bm
  hits   gperf                                     :   3.711 ns   0.27 Gv/s  12.96 c  54.66 i  4.22 i/c  0.14 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   4.320 ns   0.23 Gv/s  15.09 c  58.00 i  3.84 i/c  0.00 bm
  misses naive                                     :  12.183 ns   0.08 Gv/s  42.50 c  92.23 i  2.17 i/c  0.69 bm
  misses std::unordered_map                        :  23.604 ns   0.04 Gv/s  82.35 c  131.10 i  1.59 i/c  0.82 bm
  misses ankerl::dense                             :   5.143 ns   0.19 Gv/s  17.94 c  63.87 i  3.56 i/c  0.20 bm
  misses absl::flat_hash_map                       :   5.085 ns   0.20 Gv/s  17.72 c  72.19 i  4.07 i/c  0.14 bm
  misses frozen::unordered_map                     :  15.670 ns   0.06 Gv/s  54.66 c  66.20 i  1.21 i/c  1.19 bm
  misses kronuz::phf                               :   7.018 ns   0.14 Gv/s  24.46 c  59.40 i  2.43 i/c  0.59 bm
  misses gperf                                     :   4.712 ns   0.21 Gv/s  16.43 c  19.97 i  1.22 i/c  0.41 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :  10.792 ns   0.09 Gv/s  37.64 c  60.50 i  1.61 i/c  0.50 bm
  mixed  naive                                     :  17.097 ns   0.06 Gv/s  59.62 c  86.76 i  1.46 i/c  1.33 bm
  mixed  std::unordered_map                        :  29.496 ns   0.03 Gv/s  102.89 c  123.05 i  1.20 i/c  1.42 bm
  mixed  ankerl::dense                             :  13.356 ns   0.07 Gv/s  46.57 c  76.91 i  1.65 i/c  0.76 bm
  mixed  absl::flat_hash_map                       :  14.881 ns   0.07 Gv/s  51.88 c  96.48 i  1.86 i/c  0.65 bm
  mixed  frozen::unordered_map                     :  17.708 ns   0.06 Gv/s  61.75 c  78.39 i  1.27 i/c  1.40 bm
  mixed  kronuz::phf                               :  11.623 ns   0.09 Gv/s  40.54 c  57.92 i  1.43 i/c  1.01 bm
  mixed  gperf                                     :   8.023 ns   0.12 Gv/s  27.99 c  37.32 i  1.33 i/c  0.59 bm

=== HTTP Headers (N=20, MaxKeyLen=15) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :  14.584 ns   0.07 Gv/s  50.86 c  181.00 i  3.56 i/c  0.00 bm
  hits   naive                                     :  20.695 ns   0.05 Gv/s  72.18 c  109.32 i  1.51 i/c  1.48 bm
  hits   std::unordered_map                        :  28.813 ns   0.03 Gv/s  100.53 c  102.89 i  1.02 i/c  1.51 bm
  hits   ankerl::dense                             :  17.369 ns   0.06 Gv/s  60.59 c  96.83 i  1.60 i/c  0.89 bm
  hits   absl::flat_hash_map                       :  11.713 ns   0.09 Gv/s  40.80 c  124.45 i  3.05 i/c  0.55 bm
  hits   frozen::unordered_map                     :  21.450 ns   0.05 Gv/s  74.81 c  167.62 i  2.24 i/c  1.31 bm
  hits   kronuz::phf                               :  11.425 ns   0.09 Gv/s  39.85 c  87.69 i  2.20 i/c  0.98 bm
  hits   gperf                                     :   2.589 ns   0.39 Gv/s   9.04 c  53.00 i  5.86 i/c  0.00 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :  14.345 ns   0.07 Gv/s  50.03 c  175.00 i  3.50 i/c  0.00 bm
  misses naive                                     :  14.161 ns   0.07 Gv/s  49.39 c  107.87 i  2.18 i/c  0.64 bm
  misses std::unordered_map                        :  22.515 ns   0.04 Gv/s  78.55 c  135.96 i  1.73 i/c  0.83 bm
  misses ankerl::dense                             :   9.643 ns   0.10 Gv/s  33.62 c  71.90 i  2.14 i/c  0.61 bm
  misses absl::flat_hash_map                       :  13.374 ns   0.07 Gv/s  46.61 c  90.58 i  1.94 i/c  0.88 bm
  misses frozen::unordered_map                     :  16.226 ns   0.06 Gv/s  56.50 c  134.32 i  2.38 i/c  1.05 bm
  misses kronuz::phf                               :  12.607 ns   0.08 Gv/s  43.95 c  108.25 i  2.46 i/c  1.08 bm
  misses gperf                                     :   7.404 ns   0.14 Gv/s  25.83 c  17.18 i  0.67 i/c  0.72 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :  19.675 ns   0.05 Gv/s  68.63 c  179.00 i  2.61 i/c  0.35 bm
  mixed  naive                                     :  20.625 ns   0.05 Gv/s  71.92 c  108.88 i  1.51 i/c  1.39 bm
  mixed  std::unordered_map                        :  30.249 ns   0.03 Gv/s  105.46 c  113.92 i  1.08 i/c  1.50 bm
  mixed  ankerl::dense                             :  17.038 ns   0.06 Gv/s  59.43 c  88.49 i  1.49 i/c  0.96 bm
  mixed  absl::flat_hash_map                       :  15.829 ns   0.06 Gv/s  55.15 c  113.16 i  2.05 i/c  0.89 bm
  mixed  frozen::unordered_map                     :  22.072 ns   0.05 Gv/s  77.00 c  156.52 i  2.03 i/c  1.50 bm
  mixed  kronuz::phf                               :  15.211 ns   0.07 Gv/s  53.05 c  94.58 i  1.78 i/c  1.32 bm
  mixed  gperf                                     :   6.136 ns   0.16 Gv/s  21.40 c  41.04 i  1.92 i/c  0.34 bm

=== MIME Types (N=15, MaxKeyLen=16) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   9.057 ns   0.11 Gv/s  31.60 c  111.00 i  3.51 i/c  0.00 bm
  hits   naive                                     :  21.150 ns   0.05 Gv/s  73.78 c  103.21 i  1.40 i/c  1.50 bm
  hits   std::unordered_map                        :  28.340 ns   0.04 Gv/s  98.83 c  107.17 i  1.08 i/c  1.51 bm
  hits   ankerl::dense                             :   8.041 ns   0.12 Gv/s  28.04 c  88.20 i  3.15 i/c  0.20 bm
  hits   absl::flat_hash_map                       :   7.565 ns   0.13 Gv/s  26.39 c  117.13 i  4.44 i/c  0.07 bm
  hits   frozen::unordered_map                     :  25.245 ns   0.04 Gv/s  88.06 c  205.96 i  2.34 i/c  1.24 bm
  hits   kronuz::phf                               :  11.344 ns   0.09 Gv/s  39.47 c  97.58 i  2.47 i/c  0.88 bm
  hits   gperf                                     :   5.965 ns   0.17 Gv/s  20.80 c  67.06 i  3.22 i/c  0.27 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   8.896 ns   0.11 Gv/s  31.04 c  106.00 i  3.42 i/c  0.00 bm
  misses naive                                     :  15.087 ns   0.07 Gv/s  52.55 c  99.27 i  1.89 i/c  0.82 bm
  misses std::unordered_map                        :  23.564 ns   0.04 Gv/s  82.19 c  145.43 i  1.77 i/c  0.91 bm
  misses ankerl::dense                             :   4.117 ns   0.24 Gv/s  14.38 c  67.21 i  4.67 i/c  0.10 bm
  misses absl::flat_hash_map                       :   9.242 ns   0.11 Gv/s  32.23 c  76.72 i  2.38 i/c  0.51 bm
  misses frozen::unordered_map                     :  17.417 ns   0.06 Gv/s  60.72 c  112.25 i  1.85 i/c  1.28 bm
  misses kronuz::phf                               :  11.813 ns   0.08 Gv/s  41.18 c  103.75 i  2.52 i/c  0.94 bm
  misses gperf                                     :   8.233 ns   0.12 Gv/s  28.70 c  42.97 i  1.50 i/c  0.61 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :  15.381 ns   0.07 Gv/s  53.64 c  109.01 i  2.03 i/c  0.43 bm
  mixed  naive                                     :  21.095 ns   0.05 Gv/s  73.51 c  101.89 i  1.39 i/c  1.49 bm
  mixed  std::unordered_map                        :  29.888 ns   0.03 Gv/s  104.26 c  122.54 i  1.18 i/c  1.56 bm
  mixed  ankerl::dense                             :  12.936 ns   0.08 Gv/s  45.12 c  79.82 i  1.77 i/c  0.64 bm
  mixed  absl::flat_hash_map                       :  13.207 ns   0.08 Gv/s  46.07 c  100.98 i  2.19 i/c  0.56 bm
  mixed  frozen::unordered_map                     :  26.806 ns   0.04 Gv/s  93.53 c  168.58 i  1.80 i/c  1.68 bm
  mixed  kronuz::phf                               :  17.078 ns   0.06 Gv/s  59.57 c  100.05 i  1.68 i/c  1.31 bm
  mixed  gperf                                     :  10.064 ns   0.10 Gv/s  35.06 c  57.46 i  1.64 i/c  0.65 bm
```

macOS results (Apple clang)

```

=== URL Protocols (N=6, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   1.163 ns   0.86 Gv/s   5.34 c  45.57 i  8.54 i/c  0.00 bm
  hits   naive                                     :   5.436 ns   0.18 Gv/s  24.54 c  20.26 i  0.83 i/c  1.18 bm
  hits   std::unordered_map                        :   9.685 ns   0.10 Gv/s  43.62 c  113.57 i  2.60 i/c  1.02 bm
  hits   ankerl::dense                             :   9.770 ns   0.10 Gv/s  43.99 c  129.07 i  2.93 i/c  1.02 bm
  hits   absl::flat_hash_map                       :   7.191 ns   0.14 Gv/s  32.48 c  98.57 i  3.03 i/c  0.84 bm
  hits   frozen::unordered_map                     :   6.300 ns   0.16 Gv/s  28.46 c  80.46 i  2.83 i/c  0.87 bm
  hits   kronuz::phf                               :   4.599 ns   0.22 Gv/s  20.78 c  43.58 i  2.10 i/c  0.71 bm
  hits   gperf                                     :   4.473 ns   0.22 Gv/s  20.12 c  66.59 i  3.31 i/c  0.70 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   1.021 ns   0.98 Gv/s   4.63 c  41.32 i  8.92 i/c  0.00 bm
  misses naive                                     :   3.472 ns   0.29 Gv/s  15.70 c  18.41 i  1.17 i/c  0.68 bm
  misses std::unordered_map                        :   3.406 ns   0.29 Gv/s  15.44 c  64.74 i  4.19 i/c  0.35 bm
  misses ankerl::dense                             :   4.614 ns   0.22 Gv/s  20.86 c  103.41 i  4.96 i/c  0.35 bm
  misses absl::flat_hash_map                       :   3.369 ns   0.30 Gv/s  15.24 c  55.74 i  3.66 i/c  0.35 bm
  misses frozen::unordered_map                     :   7.841 ns   0.13 Gv/s  35.28 c  47.07 i  1.33 i/c  1.19 bm
  misses kronuz::phf                               :   4.784 ns   0.21 Gv/s  21.61 c  44.73 i  2.07 i/c  0.69 bm
  misses gperf                                     :   1.836 ns   0.54 Gv/s   8.38 c  13.41 i  1.60 i/c  0.35 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   4.617 ns   0.22 Gv/s  20.85 c  43.44 i  2.08 i/c  0.50 bm
  mixed  naive                                     :   5.339 ns   0.19 Gv/s  24.18 c  19.32 i  0.80 i/c  1.14 bm
  mixed  std::unordered_map                        :  11.169 ns   0.09 Gv/s  50.17 c  89.07 i  1.78 i/c  1.15 bm
  mixed  ankerl::dense                             :  10.818 ns   0.09 Gv/s  48.71 c  116.19 i  2.39 i/c  1.05 bm
  mixed  absl::flat_hash_map                       :  10.043 ns   0.10 Gv/s  45.20 c  77.07 i  1.71 i/c  1.06 bm
  mixed  frozen::unordered_map                     :   8.895 ns   0.11 Gv/s  40.04 c  63.74 i  1.59 i/c  1.31 bm
  mixed  kronuz::phf                               :   8.723 ns   0.11 Gv/s  39.39 c  44.17 i  1.12 i/c  1.13 bm
  mixed  gperf                                     :   5.147 ns   0.19 Gv/s  23.15 c  39.92 i  1.72 i/c  0.88 bm

=== S&P 100 Tickers (N=100, MaxKeyLen=5) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :   1.827 ns   0.55 Gv/s   8.27 c  63.57 i  7.69 i/c  0.00 bm
  hits   naive                                     :  34.728 ns   0.03 Gv/s  155.93 c  304.76 i  1.95 i/c  2.73 bm
  hits   std::unordered_map                        :   9.765 ns   0.10 Gv/s  44.10 c  118.33 i  2.68 i/c  0.82 bm
  hits   ankerl::dense                             :  14.507 ns   0.07 Gv/s  65.31 c  141.41 i  2.17 i/c  1.30 bm
  hits   absl::flat_hash_map                       :   6.693 ns   0.15 Gv/s  30.22 c  102.43 i  3.39 i/c  0.59 bm
  hits   frozen::unordered_map                     :   7.677 ns   0.13 Gv/s  34.53 c  78.99 i  2.29 i/c  0.95 bm
  hits   kronuz::phf                               :   3.701 ns   0.27 Gv/s  16.73 c  45.27 i  2.71 i/c  0.52 bm
  hits   gperf                                     :   4.751 ns   0.21 Gv/s  21.46 c  74.98 i  3.49 i/c  0.66 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :   1.720 ns   0.58 Gv/s   7.79 c  59.32 i  7.62 i/c  0.00 bm
  misses naive                                     :  25.621 ns   0.04 Gv/s  115.37 c  268.56 i  2.33 i/c  1.39 bm
  misses std::unordered_map                        :   7.754 ns   0.13 Gv/s  34.92 c  73.11 i  2.09 i/c  0.57 bm
  misses ankerl::dense                             :   4.262 ns   0.23 Gv/s  19.26 c  103.67 i  5.38 i/c  0.20 bm
  misses absl::flat_hash_map                       :   6.884 ns   0.15 Gv/s  31.05 c  59.96 i  1.93 i/c  0.57 bm
  misses frozen::unordered_map                     :   7.407 ns   0.13 Gv/s  33.51 c  49.52 i  1.48 i/c  0.72 bm
  misses kronuz::phf                               :   2.353 ns   0.42 Gv/s  10.66 c  46.07 i  4.32 i/c  0.16 bm
  misses gperf                                     :   1.518 ns   0.66 Gv/s   6.88 c  37.32 i  5.43 i/c  0.15 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :   3.329 ns   0.30 Gv/s  15.05 c  62.87 i  4.18 i/c  0.17 bm
  mixed  naive                                     :  33.996 ns   0.03 Gv/s  153.02 c  298.69 i  1.95 i/c  2.88 bm
  mixed  std::unordered_map                        :  11.633 ns   0.09 Gv/s  52.30 c  110.80 i  2.12 i/c  1.08 bm
  mixed  ankerl::dense                             :  14.512 ns   0.07 Gv/s  65.52 c  135.12 i  2.06 i/c  1.42 bm
  mixed  absl::flat_hash_map                       :   8.832 ns   0.11 Gv/s  39.62 c  95.35 i  2.41 i/c  0.90 bm
  mixed  frozen::unordered_map                     :   9.111 ns   0.11 Gv/s  41.15 c  74.17 i  1.80 i/c  1.20 bm
  mixed  kronuz::phf                               :   6.148 ns   0.16 Gv/s  27.77 c  45.42 i  1.64 i/c  0.76 bm
  mixed  gperf                                     :   6.128 ns   0.16 Gv/s  27.78 c  68.80 i  2.48 i/c  0.88 bm

=== C++ Keywords (N=15, MaxKeyLen=6) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   1.421 ns   0.70 Gv/s   6.46 c  55.57 i  8.60 i/c  0.00 bm
  hits   naive                                     :   9.252 ns   0.11 Gv/s  41.76 c  75.53 i  1.81 i/c  1.30 bm
  hits   std::unordered_map                        :   9.372 ns   0.11 Gv/s  42.33 c  110.07 i  2.60 i/c  0.96 bm
  hits   ankerl::dense                             :  11.266 ns   0.09 Gv/s  50.88 c  128.26 i  2.52 i/c  1.05 bm
  hits   absl::flat_hash_map                       :   6.111 ns   0.16 Gv/s  27.47 c  93.87 i  3.42 i/c  0.70 bm
  hits   frozen::unordered_map                     :   6.851 ns   0.15 Gv/s  30.94 c  85.28 i  2.76 i/c  0.84 bm
  hits   kronuz::phf                               :   4.402 ns   0.23 Gv/s  19.91 c  49.39 i  2.48 i/c  0.63 bm
  hits   gperf                                     :   4.614 ns   0.22 Gv/s  20.84 c  72.25 i  3.47 i/c  0.68 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   1.298 ns   0.77 Gv/s   5.89 c  51.32 i  8.72 i/c  0.00 bm
  misses naive                                     :   6.346 ns   0.16 Gv/s  28.72 c  63.91 i  2.23 i/c  0.83 bm
  misses std::unordered_map                        :   6.107 ns   0.16 Gv/s  27.59 c  90.72 i  3.29 i/c  0.34 bm
  misses ankerl::dense                             :   3.542 ns   0.28 Gv/s  16.01 c  103.20 i  6.45 i/c  0.13 bm
  misses absl::flat_hash_map                       :   2.231 ns   0.45 Gv/s  10.09 c  54.73 i  5.42 i/c  0.14 bm
  misses frozen::unordered_map                     :   9.598 ns   0.10 Gv/s  43.33 c  59.94 i  1.38 i/c  1.16 bm
  misses kronuz::phf                               :   4.529 ns   0.22 Gv/s  20.47 c  53.07 i  2.59 i/c  0.55 bm
  misses gperf                                     :   2.756 ns   0.36 Gv/s  12.55 c  19.36 i  1.54 i/c  0.41 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   5.043 ns   0.20 Gv/s  22.78 c  53.45 i  2.35 i/c  0.50 bm
  mixed  naive                                     :   8.755 ns   0.11 Gv/s  39.42 c  69.73 i  1.77 i/c  1.32 bm
  mixed  std::unordered_map                        :  12.597 ns   0.08 Gv/s  56.73 c  100.36 i  1.77 i/c  1.03 bm
  mixed  ankerl::dense                             :  10.314 ns   0.10 Gv/s  46.03 c  115.72 i  2.51 i/c  0.88 bm
  mixed  absl::flat_hash_map                       :   9.465 ns   0.11 Gv/s  42.61 c  74.28 i  1.74 i/c  0.90 bm
  mixed  frozen::unordered_map                     :  10.018 ns   0.10 Gv/s  45.22 c  72.63 i  1.61 i/c  1.35 bm
  mixed  kronuz::phf                               :   7.667 ns   0.13 Gv/s  34.68 c  51.25 i  1.48 i/c  0.98 bm
  mixed  gperf                                     :   5.773 ns   0.17 Gv/s  26.07 c  45.81 i  1.76 i/c  0.86 bm

=== HTTP Headers (N=20, MaxKeyLen=15) ===
  --- all hits ---
  hits   make_perfect_map (H&D)                    :   3.588 ns   0.28 Gv/s  16.21 c  144.07 i  8.89 i/c  0.00 bm
  hits   naive                                     :  11.115 ns   0.09 Gv/s  50.25 c  73.55 i  1.46 i/c  1.91 bm
  hits   std::unordered_map                        :  13.490 ns   0.07 Gv/s  60.53 c  116.61 i  1.93 i/c  1.50 bm
  hits   ankerl::dense                             :  15.809 ns   0.06 Gv/s  71.37 c  142.04 i  1.99 i/c  1.72 bm
  hits   absl::flat_hash_map                       :   8.560 ns   0.12 Gv/s  38.64 c  97.88 i  2.53 i/c  1.22 bm
  hits   frozen::unordered_map                     :  13.050 ns   0.08 Gv/s  58.32 c  160.67 i  2.75 i/c  1.17 bm
  hits   kronuz::phf                               :   6.816 ns   0.15 Gv/s  30.79 c  70.81 i  2.30 i/c  0.93 bm
  hits   gperf                                     :   6.742 ns   0.15 Gv/s  30.39 c  97.58 i  3.21 i/c  0.97 bm
  --- all misses ---
  misses make_perfect_map (H&D)                    :   3.606 ns   0.28 Gv/s  16.30 c  105.67 i  6.48 i/c  0.10 bm
  misses naive                                     :   6.375 ns   0.16 Gv/s  28.86 c  50.43 i  1.75 i/c  1.02 bm
  misses std::unordered_map                        :  11.040 ns   0.09 Gv/s  49.03 c  97.50 i  1.99 i/c  1.06 bm
  misses ankerl::dense                             :   7.038 ns   0.14 Gv/s  31.79 c  105.87 i  3.33 i/c  0.61 bm
  misses absl::flat_hash_map                       :   5.521 ns   0.18 Gv/s  24.94 c  62.66 i  2.51 i/c  0.73 bm
  misses frozen::unordered_map                     :   9.706 ns   0.10 Gv/s  43.82 c  124.77 i  2.85 i/c  0.83 bm
  misses kronuz::phf                               :   7.806 ns   0.13 Gv/s  35.25 c  89.11 i  2.53 i/c  0.83 bm
  misses gperf                                     :   4.465 ns   0.22 Gv/s  20.14 c  20.04 i  1.00 i/c  0.73 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (H&D)                    :   5.603 ns   0.18 Gv/s  25.33 c  131.24 i  5.18 i/c  0.35 bm
  mixed  naive                                     :  11.192 ns   0.09 Gv/s  50.41 c  65.87 i  1.31 i/c  2.03 bm
  mixed  std::unordered_map                        :  16.001 ns   0.06 Gv/s  72.08 c  110.22 i  1.53 i/c  1.70 bm
  mixed  ankerl::dense                             :  14.855 ns   0.07 Gv/s  66.84 c  129.90 i  1.94 i/c  1.55 bm
  mixed  absl::flat_hash_map                       :  10.090 ns   0.10 Gv/s  45.64 c  86.13 i  1.89 i/c  1.31 bm
  mixed  frozen::unordered_map                     :  13.668 ns   0.07 Gv/s  61.58 c  148.69 i  2.41 i/c  1.33 bm
  mixed  kronuz::phf                               :   9.640 ns   0.10 Gv/s  43.52 c  76.94 i  1.77 i/c  1.13 bm
  mixed  gperf                                     :   6.751 ns   0.15 Gv/s  30.50 c  71.70 i  2.35 i/c  0.99 bm

=== MIME Types (N=15, MaxKeyLen=16) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   2.335 ns   0.43 Gv/s  10.64 c  93.57 i  8.80 i/c  0.00 bm
  hits   naive                                     :  10.466 ns   0.10 Gv/s  47.25 c  88.32 i  1.87 i/c  1.53 bm
  hits   std::unordered_map                        :   9.102 ns   0.11 Gv/s  40.91 c  115.13 i  2.81 i/c  0.83 bm
  hits   ankerl::dense                             :   8.906 ns   0.11 Gv/s  39.99 c  133.41 i  3.34 i/c  0.83 bm
  hits   absl::flat_hash_map                       :   6.142 ns   0.16 Gv/s  27.60 c  96.87 i  3.51 i/c  0.68 bm
  hits   frozen::unordered_map                     :  15.950 ns   0.06 Gv/s  71.85 c  195.82 i  2.73 i/c  1.15 bm
  hits   kronuz::phf                               :   6.813 ns   0.15 Gv/s  30.78 c  83.72 i  2.72 i/c  0.78 bm
  hits   gperf                                     :   8.656 ns   0.12 Gv/s  39.10 c  132.47 i  3.39 i/c  1.03 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   2.288 ns   0.44 Gv/s  10.35 c  89.07 i  8.61 i/c  0.00 bm
  misses naive                                     :   7.139 ns   0.14 Gv/s  32.24 c  82.19 i  2.55 i/c  0.94 bm
  misses std::unordered_map                        :   8.727 ns   0.11 Gv/s  39.40 c  77.16 i  1.96 i/c  0.73 bm
  misses ankerl::dense                             :   3.402 ns   0.29 Gv/s  15.43 c  104.27 i  6.76 i/c  0.10 bm
  misses absl::flat_hash_map                       :   4.697 ns   0.21 Gv/s  21.23 c  57.19 i  2.69 i/c  0.53 bm
  misses frozen::unordered_map                     :  10.818 ns   0.09 Gv/s  48.57 c  105.33 i  2.17 i/c  1.13 bm
  misses kronuz::phf                               :   7.690 ns   0.13 Gv/s  34.73 c  90.03 i  2.59 i/c  0.82 bm
  misses gperf                                     :   4.303 ns   0.23 Gv/s  19.45 c  39.14 i  2.01 i/c  0.61 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :   5.920 ns   0.17 Gv/s  26.73 c  91.78 i  3.43 i/c  0.42 bm
  mixed  naive                                     :  10.530 ns   0.09 Gv/s  47.48 c  86.00 i  1.81 i/c  1.64 bm
  mixed  std::unordered_map                        :  12.359 ns   0.08 Gv/s  55.42 c  100.04 i  1.81 i/c  1.13 bm
  mixed  ankerl::dense                             :  11.464 ns   0.09 Gv/s  51.23 c  121.86 i  2.38 i/c  1.02 bm
  mixed  absl::flat_hash_map                       :   8.943 ns   0.11 Gv/s  40.37 c  81.04 i  2.01 i/c  0.94 bm
  mixed  frozen::unordered_map                     :  17.265 ns   0.06 Gv/s  77.76 c  159.70 i  2.05 i/c  1.51 bm
  mixed  kronuz::phf                               :  11.438 ns   0.09 Gv/s  51.64 c  86.24 i  1.67 i/c  1.14 bm
  mixed  gperf                                     :   8.687 ns   0.12 Gv/s  39.05 c  95.28 i  2.44 i/c  1.12 bm
```