### PR TITLE
2-byte H&D key hash and page-safe check fix

### DIFF
--- a/include/ConstexprCore/detail/gperf_generator.h
+++ b/include/ConstexprCore/detail/gperf_generator.h
@@ -528,24 +528,41 @@ constexpr std::size_t hd_bucket_hash(std::string_view key) {
     return (c0 + c1 * 3 + key.size() * 17) & 0xFF;
 }
 
-// Per-key hash for Hash-and-Displace: polynomial of first 4 bytes + length.
+// Per-key hash for Hash-and-Displace: polynomial of first N bytes + length.
+// Two variants: 2-byte (lighter, fewer instructions) and 4-byte (stronger mixing).
+// The generator tries 2-byte first; if it can't find a valid PHF, falls back to 4-byte.
 // Must match between generator (consteval) and runtime (compute_hash).
-constexpr std::size_t hd_key_hash(std::string_view key) {
-    // Branchless: always hash exactly 4 bytes, using 0 for out-of-range positions.
-    // At consteval this is just a loop; at runtime the compiler can unroll without
-    // length-dependent branches.
-    auto safe_char = [](const char* p, std::size_t len, std::size_t idx) -> std::size_t {
-        std::size_t has = static_cast<std::size_t>(idx < len);
-        std::size_t si = idx & -has;
-        return static_cast<unsigned char>(p[si]) & -has;
-    };
+
+constexpr std::size_t hd_safe_char(const char* p, std::size_t len, std::size_t idx) {
+    std::size_t has = static_cast<std::size_t>(idx < len);
+    std::size_t si = idx & -has;
+    return static_cast<unsigned char>(p[si]) & -has;
+}
+
+constexpr std::size_t hd_key_hash_2(std::string_view key) {
     std::size_t kc = key.size();
-    kc = kc * 31 + static_cast<unsigned char>(key[0]); // byte 0 always valid (len >= 1)
-    kc = kc * 31 + safe_char(key.data(), key.size(), 1);
-    kc = kc * 31 + safe_char(key.data(), key.size(), 2);
-    kc = kc * 31 + safe_char(key.data(), key.size(), 3);
+    kc = kc * 31 + static_cast<unsigned char>(key[0]);
+    kc = kc * 31 + hd_safe_char(key.data(), key.size(), 1);
     return kc;
 }
+
+constexpr std::size_t hd_key_hash_4(std::string_view key) {
+    std::size_t kc = key.size();
+    kc = kc * 31 + static_cast<unsigned char>(key[0]);
+    kc = kc * 31 + hd_safe_char(key.data(), key.size(), 1);
+    kc = kc * 31 + hd_safe_char(key.data(), key.size(), 2);
+    kc = kc * 31 + hd_safe_char(key.data(), key.size(), 3);
+    return kc;
+}
+
+// Legacy name for backward compatibility (4-byte variant).
+constexpr std::size_t hd_key_hash(std::string_view key) { return hd_key_hash_4(key); }
+
+// HD_HASH_2BYTE flag: stored in positions_[2] by the generator when the
+// 2-byte key hash was sufficient. Runtime compute_hash checks this to
+// select the lighter hash variant.
+static constexpr std::size_t HD_HASH_2BYTE_FLAG = 2;
+static constexpr std::size_t HD_HASH_4BYTE_FLAG = 4;
 
 
 // ============================================================================
@@ -605,9 +622,7 @@ consteval bool try_hash_and_displace(
 
     // Set num_positions = 0xFF to signal H&D mode to compute_hash.
     // Store the actual positions in positions[0] and positions[1].
-    // compute_hash will detect num_positions == 0xFF and use:
-    //   bucket = (char_at(key, pos[0]) + char_at(key, pos[1]) + key.size()) & 0xFF
-    //   slot = asso_values[bucket] % M
+    // positions[2] stores the key hash variant flag (2-byte or 4-byte).
     num_positions = 0xFF; // sentinel for H&D mode
     positions[0] = pos0;
     positions[1] = pos1;
@@ -639,63 +654,61 @@ consteval bool try_hash_and_displace(
         }
     }
 
-    // Initialize slots
-    for (std::size_t i = 0; i < M; ++i) slot_to_key[i] = N;
-    for (std::size_t i = 0; i < 256; ++i) asso_values[0][i] = 0;
+    // Helper: try H&D placement with a given key hash function.
+    auto try_placement = [&](auto key_hash_fn) -> bool {
+        for (std::size_t i = 0; i < M; ++i) slot_to_key[i] = N;
+        for (std::size_t i = 0; i < 256; ++i) asso_values[0][i] = 0;
 
-    // For each bucket (largest first), find a displacement value d such that
-    // (base_hash[key] + d) % M lands all keys on empty slots.
-    for (std::size_t b = 0; b < num_buckets; ++b) {
-        std::size_t ch = buckets[b].ch;
+        for (std::size_t b = 0; b < num_buckets; ++b) {
+            std::size_t ch = buckets[b].ch;
+            std::array<std::size_t, N> bucket_keys{};
+            std::size_t bk_count = 0;
+            for (std::size_t i = 0; i < N; ++i)
+                if (key_bucket[i] == ch) bucket_keys[bk_count++] = i;
 
-        // Collect key indices in this bucket
-        std::array<std::size_t, N> bucket_keys{};
-        std::size_t bk_count = 0;
-        for (std::size_t i = 0; i < N; ++i) {
-            if (key_bucket[i] == ch) bucket_keys[bk_count++] = i;
-        }
-
-        // Try displacement values d = 0, 1, ..., M*2-1.
-        // H&D hash: slot = (d + key.size()*31 + key[0]) % M
-        // The per-key contribution (key.size()*31 + key[0]) ensures keys
-        // in the same bucket get different base offsets.
-        bool placed = false;
-
-        // Displacement range: d is stored in asso_values as uint8_t, so d < 255.
-        // Also, d >= M produces duplicate slots (d + kc) % M == (d%M + kc) % M,
-        // so cap at min(M, 255) to avoid redundant iterations.
-        std::size_t max_d = M < 255 ? M : 255;
-        for (std::size_t d = 0; d < max_d; ++d) {
-            bool ok = true;
-            std::array<std::size_t, N> bucket_slots{};
-            for (std::size_t k = 0; k < bk_count; ++k) {
-                std::size_t slot = (d + hd_key_hash(keys[bucket_keys[k]])) % M;
-                if (slot_to_key[slot] != N) { ok = false; break; }
-                for (std::size_t k2 = 0; k2 < k; ++k2) {
-                    if (bucket_slots[k2] == slot) { ok = false; break; }
-                }
-                if (!ok) break;
-                bucket_slots[k] = slot;
-            }
-
-            if (ok) {
-                asso_values[0][ch] = d;
+            bool placed = false;
+            std::size_t max_d = M < 255 ? M : 255;
+            for (std::size_t d = 0; d < max_d; ++d) {
+                bool ok = true;
+                std::array<std::size_t, N> bucket_slots{};
                 for (std::size_t k = 0; k < bk_count; ++k) {
-                    slot_to_key[bucket_slots[k]] = bucket_keys[k];
+                    std::size_t slot = (d + key_hash_fn(keys[bucket_keys[k]])) % M;
+                    if (slot_to_key[slot] != N) { ok = false; break; }
+                    for (std::size_t k2 = 0; k2 < k; ++k2) {
+                        if (bucket_slots[k2] == slot) { ok = false; break; }
+                    }
+                    if (!ok) break;
+                    bucket_slots[k] = slot;
                 }
-                placed = true;
-                break;
+                if (ok) {
+                    asso_values[0][ch] = d;
+                    for (std::size_t k = 0; k < bk_count; ++k)
+                        slot_to_key[bucket_slots[k]] = bucket_keys[k];
+                    placed = true;
+                    break;
+                }
             }
+            if (!placed) return false;
         }
+        std::size_t filled = 0;
+        for (std::size_t i = 0; i < M; ++i)
+            if (slot_to_key[i] != N) ++filled;
+        return filled == N;
+    };
 
-        if (!placed) return false; // Could not place this bucket
+    // Try 2-byte key hash first (lighter runtime: 2 rounds instead of 4).
+    if (try_placement([](std::string_view k) { return hd_key_hash_2(k); })) {
+        positions[2] = HD_HASH_2BYTE_FLAG;
+        return true;
     }
 
-    // Verify all N keys are placed
-    std::size_t filled = 0;
-    for (std::size_t i = 0; i < M; ++i)
-        if (slot_to_key[i] != N) ++filled;
-    return filled == N;
+    // Fall back to 4-byte key hash (stronger mixing).
+    if (try_placement([](std::string_view k) { return hd_key_hash_4(k); })) {
+        positions[2] = HD_HASH_4BYTE_FLAG;
+        return true;
+    }
+
+    return false;
 }
 
 // Try Hash-and-Displace for a specific table size M.

--- a/include/ConstexprCore/detail/neon_compare.h
+++ b/include/ConstexprCore/detail/neon_compare.h
@@ -58,7 +58,7 @@ CONSTEXPRCORE_NO_SANITIZE_ADDRESS constexprcore_really_inline uint8x16_t page_sa
     // On Apple Silicon, the page size is 16KB, but it could change in the future.
     // Apple could decide to go back to 4KB pages. Or whatever. What we can
     // expect however is that nobody will go down under 4KB pages, so checking the lower 12 bits is a safe bet.
-    if (__builtin_expect((addr & 4096) <= 4096 - 8, 1)) {
+    if (__builtin_expect((addr & 4095) <= 4080, 1)) {
         return vld1q_u8(reinterpret_cast<const uint8_t*>(p));
     }
     alignas(16) std::uint8_t buf[16] = {};

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -432,8 +432,13 @@ struct perfect_hash_set {
 
     [[nodiscard]] constexpr constexprcore_really_inline std::size_t compute_hash(std::string_view key) const noexcept {
         if (num_positions_ == HD_MODE) {
-            // H&D mode: uses shared hd_bucket_hash + hd_key_hash from generator.
-            std::size_t h = asso_values_[0][detail::hd_bucket_hash(key)] + detail::hd_key_hash(key);
+            // H&D mode: bucket hash + key hash. positions_[2] selects the key hash variant.
+            // The 2-byte variant saves ~10 insn by skipping 2 safe_char rounds.
+            std::size_t bucket = detail::hd_bucket_hash(key);
+            std::size_t kh = (positions_[2] == detail::HD_HASH_2BYTE_FLAG)
+                ? detail::hd_key_hash_2(key)
+                : detail::hd_key_hash_4(key);
+            std::size_t h = asso_values_[0][bucket] + kh;
             if constexpr (TABLE_SIZE_IS_POW2)
                 return h & (TableSize - 1);
             else


### PR DESCRIPTION
## Summary

Two changes: a consteval-driven optimization for H&D key sets, and a bug fix for the page-safety check introduced in 1cc8f73.

### Results (Apple M3 Max, all-hits, `sudo` perf counters)

| Key Set | Before | After | Δ Time | Δ Insn |
|---------|--------|-------|--------|--------|
| **Headers50** (N=50, MKL=19) | 3.51 ns / 95 i | **2.97 ns / 80 i** | **-15%** | **-15** |
| Tickers (N=100, MKL=5) | 2.25 ns / 73 i | 2.25 ns / 73 i | — | — |
| All gperf sets | unchanged | unchanged | — | — |

---

## 2-byte H&D key hash (consteval auto-selection)

The H&D per-key hash (`hd_key_hash`) uses a polynomial chain over 4 key bytes: `kc = kc*31 + safe_char(byte_i)` for i=0..3. Each `safe_char` round generates ~5 branchless ARM64 instructions (compare, mask, conditional load, mask, multiply-add). For key sets where 2 bytes of mixing already produce a collision-free PHF, rounds 2-3 are wasted work.

**Approach.** Add `hd_key_hash_2` (2-round variant). The consteval generator tries it first:
1. Group keys by `hd_bucket_hash` (unchanged)
2. Attempt displacement placement using the 2-byte key hash
3. If all N keys land in distinct slots → success, store `HD_HASH_2BYTE_FLAG` in `positions_[2]`
4. If collisions → retry with the full 4-byte key hash, store `HD_HASH_4BYTE_FLAG`

At runtime, `compute_hash` checks `positions_[2]` to dispatch to the lighter variant. Since `positions_[2]` is a struct constant, the branch is perfectly predicted (0 bm).

**Why it works for Headers50 but not Tickers.** Headers50 has 50 keys in 64 slots (78% load factor). The keys have high first-two-byte entropy (e.g., "Accept" vs "Cache-Control" vs "If-Modified-Since") — 2 bytes plus length provide enough mixing. Tickers has 100 keys in 128 slots with many short keys sharing first bytes (e.g., "BA", "BAC", "BK", "BKNG", "BLK", "BMY") — 2 bytes can't distinguish them all, so the generator automatically falls back to 4 bytes.

---

## Bug fix: page-safe check (`addr & 4096` → `addr & 4095`)

Commit 1cc8f73 changed the NEON page-boundary check to use 4KB pages but used `(addr & 4096)` instead of `(addr & 4095)`. The expression `addr & 4096` isolates bit 12 only (result: 0 or 4096), so the condition `4096 <= 4088` is false for 50% of addresses. This forces half of all lookups into the slow byte-by-byte fallback path, causing:
- 0.55-1.22 branch misses per lookup (was 0.00)
- IPC crash from 8+ to 2-3
- All NEON key sets regressed to 9-12 ns

Fixed to `(addr & 4095) <= 4080` which correctly masks the lower 12 bits for a 4KB page offset check.

## Test plan
- [x] All 39 unit tests pass
- [x] All 7 key sets pass `--verify` correctness checks
- [x] Page-safe fix: 0 branch misses restored on all single-pass NEON paths
- [x] 2-byte hash: generator correctly falls back to 4-byte for Tickers (N=100)