### PR TITLE
Enable NEON two-pass comparison for MKL 17-32 on ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ target_link_libraries(perfect_hash INTERFACE
     ConstexprCore::useful_abstractions
 )
 
+# Enable NEON/SSE2 two-pass comparison for MaxKeyLen 17-32 on supported platforms.
+target_compile_definitions(perfect_hash INTERFACE
+    $<$<BOOL:$<PLATFORM_ID:Darwin>>:CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE=1>
+)
+
 # Tests
 option(PH_BUILD_TESTS "Build tests" ON)
 if(PH_BUILD_TESTS)


### PR DESCRIPTION
## Summary

Enable the `neon_compare_32` path for MaxKeyLen 17-32 on ARM64 by setting `CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE` via CMake. The implementation already exists but was gated behind an undefined macro.

## Benchmark (Apple M3 Max, all-hits, `sudo` perf counters)

| Key Set | Before | After | Δ Time | Δ Insn |
|---------|--------|-------|--------|--------|
| **Headers50** (N=50, MKL=19) | 5.31 ns / 169 i | **2.64 ns / 69 i** | **-50%** | **-100** |
| All other key sets | unchanged | unchanged | — | — |

The scalar path for MKL > 16 uses `pack_input_()` (8 safe_byte calls) plus a byte loop for bytes 8..MKL-1. For MKL=19 that's 19 branchless conditional byte loads ≈ 100+ instructions just for comparison. The NEON two-pass path (`neon_compare_32`) replaces this with two vectorized 16-byte loads + TBL mask + vceqq — ~10 NEON instructions total.

Only Headers50 is affected (the only key set with MKL > 16). The 0.10 branch misses per lookup come from the `tail_len > 0` conditional between the two NEON passes (keys range from 2-19 bytes, straddling the 16-byte boundary).

## Test plan
- [x] All 39 unit tests pass
- [x] All 8 key sets pass `--verify`
- [x] No regressions on MKL ≤ 16 key sets