### PR TITLE
careful default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,11 +86,6 @@ target_link_libraries(perfect_hash INTERFACE
     ConstexprCore::useful_abstractions
 )
 
-# Enable NEON/SSE2 two-pass comparison for MaxKeyLen 17-32 on supported platforms.
-target_compile_definitions(perfect_hash INTERFACE
-    $<$<BOOL:$<PLATFORM_ID:Darwin>>:CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE=1>
-)
-
 # Tests
 option(PH_BUILD_TESTS "Build tests" ON)
 if(PH_BUILD_TESTS)

--- a/include/ConstexprCore/perfect_hash.h
+++ b/include/ConstexprCore/perfect_hash.h
@@ -22,6 +22,14 @@
 #include <ConstexprCore/detail/neon_compare.h>
 #include <ConstexprCore/detail/sse2_compare.h>
 
+#ifndef CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE
+#if defined(__clang__) && CONSTEXPRCORE_HAS_NEON
+#define CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE 1
+#else
+#define CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE 0
+#endif
+#endif
+
 
 
 namespace ConstexprCore {


### PR DESCRIPTION
Let us enable CONSTEXPRCORE_USE_NEON_FOR_32_BYTE_COMPARE when under clang and ARM. Not generally.