### PR TITLE
adding benchmark for reflection.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if(PH_BUILD_BENCHMARKS)
 endif()
 
 # Examples (requires C++26 reflection support)
-option(PH_BUILD_EXAMPLES "Build examples (requires C++26 -freflection)" OFF)
+option(PH_BUILD_EXAMPLES "Build examples (requires C++26 -freflection)" ON)
 if(PH_BUILD_EXAMPLES)
     add_subdirectory(examples/reflect)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -33,15 +33,17 @@ FetchContent_Declare(
     constexpr_phf
     GIT_REPOSITORY https://github.com/Kronuz/constexpr-phf.git
     GIT_TAG master
+    SOURCE_SUBDIR _skip_add_subdirectory
 )
-FetchContent_Populate(constexpr_phf)
+FetchContent_MakeAvailable(constexpr_phf)
 
 FetchContent_Declare(
     pthash
     GIT_REPOSITORY https://github.com/jermp/pthash.git
     GIT_TAG master
+    SOURCE_SUBDIR _skip_add_subdirectory
 )
-FetchContent_Populate(pthash)
+FetchContent_MakeAvailable(pthash)
 
 # Create our own target to avoid pthash's INTERFACE compile options
 # (e.g. -march=native, -ggdb, -Wall) from propagating to our targets.

--- a/examples/reflect/CMakeLists.txt
+++ b/examples/reflect/CMakeLists.txt
@@ -4,6 +4,16 @@
 #   - Bloomberg Clang P2996 fork with -freflection
 #   - GCC 15+ with -freflection (when available)
 
+# ── Fetch dependencies ──────────────────────────────────────────────────────
+include(FetchContent)
+
+FetchContent_Declare(
+    counters
+    GIT_REPOSITORY https://github.com/lemire/counters.git
+    GIT_TAG v3.0.0
+)
+FetchContent_MakeAvailable(counters)
+
 # ── Detect C++26 reflection support ─────────────────────────────────────────��
 # Try compiling a minimal reflection snippet. If the compiler doesn't support
 # it, skip all targets with a message instead of failing the build.
@@ -25,7 +35,7 @@ set(_REFLECT_TEST_SOURCE "
 #error No reflection header found
 #endif
 struct S { int x; double y; };
-consteval auto test() { return std::meta::nonstatic_data_members_of(^S).size(); }
+consteval auto test() { return std::meta::nonstatic_data_members_of(^^S, std::meta::access_context::current()).size(); }
 static_assert(test() == 2);
 int main() {}
 ")
@@ -33,12 +43,14 @@ int main() {}
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/_reflect_check.cpp" "${_REFLECT_TEST_SOURCE}")
 
 try_compile(HAS_CPP26_REFLECTION
-    "${CMAKE_CURRENT_BINARY_DIR}/_reflect_try"
+    "${CMAKE_BINARY_DIR}/cmake_try_compile_reflect"
     SOURCES "${CMAKE_CURRENT_BINARY_DIR}/_reflect_check.cpp"
-    CMAKE_FLAGS "-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} ${_REFLECT_TEST_FLAGS}"
+    COMPILE_DEFINITIONS ${_REFLECT_TEST_FLAGS}
+    OUTPUT_VARIABLE REFLECTION_COMPILE_OUTPUT
 )
 
 if(NOT HAS_CPP26_REFLECTION)
+    message(STATUS "reflect: C++26 reflection compilation failed. Compiler output:\n${REFLECTION_COMPILE_OUTPUT}")
     message(STATUS "reflect: C++26 reflection not supported by this compiler, skipping reflect targets")
     return()
 endif()
@@ -57,6 +69,8 @@ target_link_libraries(constexprcore_reflect INTERFACE
     ConstexprCore::perfect_hash
 )
 
+
+
 # Compiler flags for reflection support.
 # Best configured via CMAKE_CXX_FLAGS="-std=c++26 -freflection" at cmake configure time.
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
@@ -64,7 +78,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -freflection -fexpansion-statements -stdlib=libc++)
     target_link_options(constexprcore_reflect INTERFACE -stdlib=libc++)
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(constexprcore_reflect INTERFACE -freflection)
+    target_compile_options(constexprcore_reflect INTERFACE -std=c++26 -freflection)
 endif()
 
 target_compile_options(constexprcore_reflect INTERFACE
@@ -75,6 +89,10 @@ target_compile_options(constexprcore_reflect INTERFACE
 # ── Demo ─────────────────────────────────────────────────────────────────────
 add_executable(reflect_demo examples/basic_usage.cpp)
 target_link_libraries(reflect_demo PRIVATE ConstexprCore::reflect)
+
+# ── Benchmark ────────────────────────────────────────────────────────────────
+add_executable(bench_reflect bench_reflect.cpp)
+target_link_libraries(bench_reflect PRIVATE ConstexprCore::reflect counters::counters)
 
 # ── Tests ────────────────────────────────────────────────────────────────────
 if(TARGET doctest::doctest)

--- a/examples/reflect/bench_reflect.cpp
+++ b/examples/reflect/bench_reflect.cpp
@@ -1,0 +1,91 @@
+#include <cstddef>
+#include <reflect/reflect.h>
+#include "counters/bench.h"
+#include <iostream>
+#include <vector>
+#include <string_view>
+#include <random>
+#include <print>
+#include "counters/bench.h"
+#include "ConstexprCore/perfect_hash.h"
+
+void pretty_print(const std::string &name, size_t num_values,
+                  counters::event_aggregate agg) {
+  std::print("  {:<48} : ", name);
+  std::print(" {:6.3f} ns ", agg.fastest_elapsed_ns() / double(num_values));
+  std::print(" {:5.2f} Gv/s", double(num_values) / agg.fastest_elapsed_ns());
+  if (counters::has_performance_counters()) {
+    std::print("  {:5.2f} c  {:5.2f} i  {:4.2f} i/c  {:4.2f} bm",
+               agg.fastest_cycles() / double(num_values),
+               agg.fastest_instructions() / double(num_values),
+               agg.fastest_instructions() / double(agg.fastest_cycles()),
+               agg.fastest_branch_misses() / double(num_values));
+  }
+  std::print("\n");
+}
+
+struct Person {
+    std::string name;
+    int age;
+    double height;
+};
+
+template <class Function1, class Function2>
+counters::event_aggregate shuffle_bench(Function1 &&function1,
+                                        Function2 &&function2,
+                                        size_t min_repeat = 300) {
+  static thread_local counters::event_collector collector;
+  auto fn = std::forward<Function1>(function1);
+  auto fn2 = std::forward<Function2>(function2);
+  counters::event_aggregate aggregate{};
+  for (size_t i = 0; i < min_repeat; i++) {
+    collector.start();
+    fn();
+    aggregate << collector.end();
+    fn2();
+  }
+  return aggregate;
+}
+
+int main() {
+    Person p{"Alice", 30, 1.75};
+
+    std::vector<std::string_view> keys = {"name", "age", "height"};
+    for(int i = 0; i < 1000; ++i) {
+        keys.push_back("name");
+        keys.push_back("age");
+        keys.push_back("height");
+    }
+    std::mt19937_64 gen(42);
+    auto shuffle = [&]() {
+        std::shuffle(keys.begin(), keys.end(), gen);
+    };
+    auto reflect_fn = [&]() {
+        for (auto key : keys) {
+            try {
+                auto val = ConstexprCore::reflect::reflect_get(p, key);
+            } catch (const std::exception& e) {
+                // Should not happen for valid keys
+                std::cerr << "Exception: " << e.what() << std::endl;
+            }
+        }
+    };
+
+    pretty_print("reflect_get Person fields", keys.size(),
+                 shuffle_bench(reflect_fn, shuffle));
+    static constexpr auto protocol_phf =
+    ConstexprCore::make_perfect_map<
+        ConstexprCore::kv<"name", 0>,
+        ConstexprCore::kv<"age", 1>,
+        ConstexprCore::kv<"height", 2>>();
+    auto fn = [&]() {
+        size_t idx = 0;
+        for (auto key : keys) {
+            idx += *protocol_phf.lookup(key);
+        }
+        volatile auto sink = idx; // prevent optimization
+    };
+    pretty_print("reflect_get Person fields", keys.size(),
+                 shuffle_bench(fn, shuffle));
+    return 0;
+}

--- a/examples/reflect/bench_reflect.cpp
+++ b/examples/reflect/bench_reflect.cpp
@@ -6,7 +6,6 @@
 #include <string_view>
 #include <random>
 #include <print>
-#include "counters/bench.h"
 #include "ConstexprCore/perfect_hash.h"
 
 void pretty_print(const std::string &name, size_t num_values,
@@ -24,10 +23,17 @@ void pretty_print(const std::string &name, size_t num_values,
   std::print("\n");
 }
 
-struct Person {
-    std::string name;
-    int age;
-    double height;
+struct stats {
+    int total_items;          // Total number of items processed
+    int successful_operations; // Number of operations that succeeded
+    int failed_operations;     // Number of operations that failed
+    int warnings;             // Number of warnings encountered
+    int errors;               // Number of errors encountered
+    int retries;              // Number of retry attempts
+    int bytes_processed;      // Total bytes processed
+    int records_read;         // Number of records read
+    int records_written;      // Number of records written
+    int records_validated;    // Number of records that passed validation
 };
 
 template <class Function1, class Function2>
@@ -47,45 +53,54 @@ counters::event_aggregate shuffle_bench(Function1 &&function1,
   return aggregate;
 }
 
-int main() {
-    Person p{"Alice", 30, 1.75};
+auto getshit(stats &p, std::string_view key) {
+    return  ConstexprCore::reflect::reflect_get(p, key);
+}
 
-    std::vector<std::string_view> keys = {"name", "age", "height"};
+int main() {
+    stats p{10, 5, 3, 1, 2, 0, 100, 50, 25, 10};
+
+    std::vector<std::string_view> keys;
     for(int i = 0; i < 1000; ++i) {
-        keys.push_back("name");
-        keys.push_back("age");
-        keys.push_back("height");
+        keys.push_back("total_items");
+        keys.push_back("successful_operations");
+        keys.push_back("failed_operations");
+        keys.push_back("warnings");
+        keys.push_back("errors");
+        keys.push_back("retries");
+        keys.push_back("bytes_processed");
+        keys.push_back("records_read");
+        keys.push_back("records_written");
+        keys.push_back("records_validated");
     }
     std::mt19937_64 gen(42);
     auto shuffle = [&]() {
         std::shuffle(keys.begin(), keys.end(), gen);
     };
+    auto naive_fn = [&]() {
+        for (auto key : keys) {
+            if(key == "total_items") p.total_items++;
+            else if(key == "successful_operations") p.successful_operations++;
+            else if(key == "failed_operations") p.failed_operations++;
+            else if(key == "warnings") p.warnings++;
+            else if(key == "errors") p.errors++;
+            else if(key == "retries") p.retries++;
+            else if(key == "bytes_processed") p.bytes_processed++;
+            else if(key == "records_read") p.records_read++;
+            else if(key == "records_written") p.records_written++;
+            else if(key == "records_validated") p.records_validated++;
+            else throw std::runtime_error("Unknown key: " + std::string(key));
+        }
+    };
+    pretty_print("naive", keys.size(),
+                 shuffle_bench(naive_fn, shuffle));
     auto reflect_fn = [&]() {
         for (auto key : keys) {
-            try {
-                auto val = ConstexprCore::reflect::reflect_get(p, key);
-            } catch (const std::exception& e) {
-                // Should not happen for valid keys
-                std::cerr << "Exception: " << e.what() << std::endl;
-            }
+            ConstexprCore::reflect::get_attribute<int>(p, key)++;
         }
     };
 
-    pretty_print("reflect_get Person fields", keys.size(),
+    pretty_print("get_attribute", keys.size(),
                  shuffle_bench(reflect_fn, shuffle));
-    static constexpr auto protocol_phf =
-    ConstexprCore::make_perfect_map<
-        ConstexprCore::kv<"name", 0>,
-        ConstexprCore::kv<"age", 1>,
-        ConstexprCore::kv<"height", 2>>();
-    auto fn = [&]() {
-        size_t idx = 0;
-        for (auto key : keys) {
-            idx += *protocol_phf.lookup(key);
-        }
-        volatile auto sink = idx; // prevent optimization
-    };
-    pretty_print("reflect_get Person fields", keys.size(),
-                 shuffle_bench(fn, shuffle));
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/examples/reflect/include/reflect/reflect.h
+++ b/examples/reflect/include/reflect/reflect.h
@@ -1,20 +1,19 @@
 #ifndef CONSTEXPRCORE_REFLECT_H
 #define CONSTEXPRCORE_REFLECT_H
 
-// C++26 reflection guard: skip this header entirely if the compiler
-// doesn't support reflection, so including it is a no-op rather than
-// a hard compile error.
-#if __has_include(<meta>)
-#include <meta>
+#include <version>
+
+// technically, we should rely on version and __cpp_reflection
 #define CONSTEXPRCORE_HAS_REFLECTION 1
-#elif __has_include(<experimental/meta>)
-#include <experimental/meta>
+
+#ifndef CONSTEXPRCORE_HAS_REFLECTION
+#if defined(__cpp_reflection) && __cpp_reflection >= 201902L
 #define CONSTEXPRCORE_HAS_REFLECTION 1
-#else
-#define CONSTEXPRCORE_HAS_REFLECTION 0
-#endif
+#endif 
+#endif // CONSTEXPRCORE_HAS_REFLECTION
 
 #if CONSTEXPRCORE_HAS_REFLECTION
+#include <meta>
 
 // ── Compiler compatibility ──────────────────────────────────────────────────
 //

--- a/examples/reflect/include/reflect/reflect.h
+++ b/examples/reflect/include/reflect/reflect.h
@@ -13,7 +13,11 @@
 #endif // CONSTEXPRCORE_HAS_REFLECTION
 
 #if CONSTEXPRCORE_HAS_REFLECTION
+#if __has_include(<meta>)
 #include <meta>
+#else
+#include <experimental/meta>
+#endif
 
 // ── Compiler compatibility ──────────────────────────────────────────────────
 //
@@ -173,6 +177,27 @@ void dispatch(auto&& obj, std::size_t idx, F&& f,
     }()) || ...);
 }
 
+// Recursive value-producing dispatch: returns V directly from the matched
+// branch so NRVO can construct the result in the caller's storage. Avoids
+// the std::optional<V> + std::move round-trip that a fold expression would
+// require (each std::optional operation adds a variant move + destruction,
+// doubling the cost when V contains types with non-trivial destructors like
+// std::string).
+template <typename T, typename V, std::size_t I>
+V get_value(const T& obj, std::size_t idx) {
+    using Meta = type_meta<T>;
+    if constexpr (I >= Meta::N) {
+        // Unreachable: idx is always < N because index_of validated it.
+        __builtin_unreachable();
+    } else {
+        constexpr auto mem = Meta::members_[I];
+        if (idx == I) {
+            return V{typename V::variant_type(std::in_place_index<I>, obj.[:mem:])};
+        }
+        return get_value<T, V, I + 1>(obj, idx);
+    }
+}
+
 } // namespace detail
 
 // ============================================================================
@@ -201,22 +226,9 @@ auto reflect_get(const T& obj, std::string_view field_name) {
     using V = detail::field_value_t<T>;
     auto idx = Meta::set.index_of(field_name);
     if (!idx) throw std::runtime_error("Unknown field: " + std::string(field_name));
-
-    // Construct the variant directly with the matched alternative via
-    // std::in_place_index. Avoids default-constructing the variant (which
-    // would fail if the first field type isn't default-constructible).
-    std::optional<V> result;
-    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        (([&]() -> bool {
-            if (*idx == Is) {
-                constexpr auto mem = Meta::members_[Is];
-                result.emplace(V{typename V::variant_type(std::in_place_index<Is>, obj.[:mem:])});
-                return true;
-            }
-            return false;
-        }()) || ...);
-    }(std::make_index_sequence<Meta::N>{});
-    return std::move(*result);
+    // Dispatch to the matching branch; returns V via NRVO, avoiding the
+    // double variant construction/destruction cost of a fold + optional pattern.
+    return detail::get_value<T, V, 0>(obj, *idx);
 }
 
 template <typename T, typename V>

--- a/examples/reflect/include/reflect/reflect.h
+++ b/examples/reflect/include/reflect/reflect.h
@@ -51,6 +51,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -183,6 +184,77 @@ void dispatch(auto&& obj, std::size_t idx, F&& f,
 // require (each std::optional operation adds a variant move + destruction,
 // doubling the cost when V contains types with non-trivial destructors like
 // std::string).
+[[noreturn, gnu::cold, gnu::noinline]]
+inline void throw_unknown_field(std::string_view name) {
+    throw std::runtime_error("Unknown field: " + std::string(name));
+}
+
+// Count fields whose type equals U. Consumed by get_attribute<U>(obj)
+// to diagnose "no match" vs "ambiguous" at compile time.
+template <typename T, typename U>
+consteval std::size_t count_type_matches() {
+    constexpr auto& members = type_meta<T>::members_;
+    std::size_t count = 0;
+    for (std::size_t i = 0; i < type_meta<T>::N; ++i)
+        if (std::meta::type_of(members[i]) == CONSTEXPRCORE_REFLECT_OF(U)) ++count;
+    return count;
+}
+
+// Precondition: count_type_matches<T, U>() == 1.
+template <typename T, typename U>
+consteval std::size_t find_unique_type_index() {
+    constexpr auto& members = type_meta<T>::members_;
+    for (std::size_t i = 0; i < type_meta<T>::N; ++i)
+        if (std::meta::type_of(members[i]) == CONSTEXPRCORE_REFLECT_OF(U)) return i;
+    return type_meta<T>::N;
+}
+
+// Indices into type_meta<T>::members_ for fields whose type is U, in source order.
+template <typename T, typename U>
+consteval auto u_field_indices() {
+    constexpr std::size_t K = count_type_matches<T, U>();
+    std::array<std::size_t, K> result{};
+    std::size_t j = 0;
+    for (std::size_t i = 0; i < type_meta<T>::N; ++i) {
+        if (std::meta::type_of(type_meta<T>::members_[i]) == CONSTEXPRCORE_REFLECT_OF(U)) {
+            result[j++] = i;
+        }
+    }
+    return result;
+}
+
+template <typename T, typename U, std::size_t... Js>
+consteval auto u_names_impl(std::index_sequence<Js...>) {
+    constexpr auto indices = u_field_indices<T, U>();
+    return std::array<std::string_view, sizeof...(Js)>{
+        type_meta<T>::names[indices[Js]]...
+    };
+}
+
+template <typename T, typename U, std::size_t... Js>
+consteval auto u_ptrs_impl(std::index_sequence<Js...>) {
+    constexpr auto indices = u_field_indices<T, U>();
+    return std::array<U T::*, sizeof...(Js)>{
+        (&[:type_meta<T>::members_[indices[Js]]:])...
+    };
+}
+
+// Per-(T, U) metadata: PHF over the names of U-typed fields of T, plus a
+// pointer-to-member table in matching order. Turns runtime dispatch into
+// one indexed load + one indirect member access — no branch chain.
+template <typename T, typename U>
+struct u_meta {
+    static constexpr std::size_t K = count_type_matches<T, U>();
+    static constexpr auto names = u_names_impl<T, U>(std::make_index_sequence<K>{});
+    static constexpr auto phf   = ConstexprCore::compute_phf(names);
+    static constexpr std::size_t TS  = phf.table_size;
+    static constexpr std::size_t MKL = max_name_len(names);
+    static constexpr auto set =
+        ConstexprCore::make_perfect_set_from_phf<K, TS, MKL>(names, phf);
+    static constexpr auto ptrs =
+        u_ptrs_impl<T, U>(std::make_index_sequence<K>{});
+};
+
 template <typename T, typename V, std::size_t I>
 V get_value(const T& obj, std::size_t idx) {
     using Meta = type_meta<T>;
@@ -225,10 +297,10 @@ auto reflect_get(const T& obj, std::string_view field_name) {
     using Meta = detail::type_meta<T>;
     using V = detail::field_value_t<T>;
     auto idx = Meta::set.index_of(field_name);
-    if (!idx) throw std::runtime_error("Unknown field: " + std::string(field_name));
-    // Dispatch to the matching branch; returns V via NRVO, avoiding the
-    // double variant construction/destruction cost of a fold + optional pattern.
-    return detail::get_value<T, V, 0>(obj, *idx);
+    if  (idx) [[likely]]   {
+        return detail::get_value<T, V, 0>(obj, *idx);
+    }
+    detail::throw_unknown_field(field_name);
 }
 
 template <typename T, typename V>
@@ -283,6 +355,37 @@ void reflect_for_each(T& obj, F&& visitor) {
 template <typename T>
 bool reflect_has(std::string_view field_name) {
     return detail::type_meta<T>::set.contains(field_name);
+}
+
+
+// Name-based typed field access. Dispatch is a PHF over only the U-typed
+// fields of T, followed by a single indexed pointer-to-member load — no
+// branch chain, no mispredict penalty on random keys. Throws if the name
+// is unknown in T or names a field of a different type (both cases look
+// the same to the U-subset PHF). Ill-formed at compile time if T has no
+// field of type U at all.
+template <typename U, typename T>
+constexprcore_really_inline U& get_attribute(T& obj, std::string_view field_name) {
+    static_assert(detail::count_type_matches<T, U>() > 0,
+                  "get_attribute: T has no field of this type");
+    using UM = detail::u_meta<T, U>;
+    auto idx = UM::set.index_of(field_name);
+    if (idx) [[likely]] {
+        return obj.*UM::ptrs[*idx];
+    }
+    detail::throw_unknown_field(field_name);
+}
+
+template <typename U, typename T>
+constexprcore_really_inline const U& get_attribute(const T& obj, std::string_view field_name) {
+    static_assert(detail::count_type_matches<T, U>() > 0,
+                  "get_attribute: T has no field of this type");
+    using UM = detail::u_meta<T, U>;
+    auto idx = UM::set.index_of(field_name);
+    if (idx) [[likely]] {
+        return obj.*UM::ptrs[*idx];
+    }
+    detail::throw_unknown_field(field_name);
 }
 
 } // namespace ConstexprCore::reflect


### PR DESCRIPTION

Ok, so I change the benchmark, and introduced a new function called `get_attribute`.

You can do...

```cpp

struct stats {
    int total_items;          // Total number of items processed
    int successful_operations; // Number of operations that succeeded
    int failed_operations;     // Number of operations that failed
    int warnings;             // Number of warnings encountered
    int errors;               // Number of errors encountered
    int retries;              // Number of retry attempts
    int bytes_processed;      // Total bytes processed
    int records_read;         // Number of records read
    int records_written;      // Number of records written
    int records_validated;    // Number of records that passed validation
};

stats p;

ConstexprCore::reflect::get_attribute<int>(p, "records_validated")
```

And it will return a reference to `p. records_validated`.

This is much faster than the `reflect_get` approach.

I wrote a benchmark that shows small benefits compared to the naive approach:

```
./build16/examples/reflect/bench_reflect 
  naive                                            :   2.739 ns   0.37 Gv/s   7.64 c  22.59 i  2.96 i/c  0.01 bm
  get_attribute                                    :   2.311 ns   0.43 Gv/s   8.10 c  38.02 i  4.69 i/c  0.00 bm
```

It is not a whole lot but it would come 'for free'.