### PR TITLE
Fix reflect_get NRVO: 4.79 ns → 3.18 ns on GCC trunk

### DIFF
--- a/examples/reflect/include/reflect/reflect.h
+++ b/examples/reflect/include/reflect/reflect.h
@@ -13,7 +13,11 @@
 #endif // CONSTEXPRCORE_HAS_REFLECTION
 
 #if CONSTEXPRCORE_HAS_REFLECTION
+#if __has_include(<meta>)
 #include <meta>
+#else
+#include <experimental/meta>
+#endif
 
 // ── Compiler compatibility ──────────────────────────────────────────────────
 //
@@ -173,6 +177,27 @@ void dispatch(auto&& obj, std::size_t idx, F&& f,
     }()) || ...);
 }
 
+// Recursive value-producing dispatch: returns V directly from the matched
+// branch so NRVO can construct the result in the caller's storage. Avoids
+// the std::optional<V> + std::move round-trip that a fold expression would
+// require (each std::optional operation adds a variant move + destruction,
+// doubling the cost when V contains types with non-trivial destructors like
+// std::string).
+template <typename T, typename V, std::size_t I>
+V get_value(const T& obj, std::size_t idx) {
+    using Meta = type_meta<T>;
+    if constexpr (I >= Meta::N) {
+        // Unreachable: idx is always < N because index_of validated it.
+        __builtin_unreachable();
+    } else {
+        constexpr auto mem = Meta::members_[I];
+        if (idx == I) {
+            return V{typename V::variant_type(std::in_place_index<I>, obj.[:mem:])};
+        }
+        return get_value<T, V, I + 1>(obj, idx);
+    }
+}
+
 } // namespace detail
 
 // ============================================================================
@@ -201,22 +226,9 @@ auto reflect_get(const T& obj, std::string_view field_name) {
     using V = detail::field_value_t<T>;
     auto idx = Meta::set.index_of(field_name);
     if (!idx) throw std::runtime_error("Unknown field: " + std::string(field_name));
-
-    // Construct the variant directly with the matched alternative via
-    // std::in_place_index. Avoids default-constructing the variant (which
-    // would fail if the first field type isn't default-constructible).
-    std::optional<V> result;
-    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-        (([&]() -> bool {
-            if (*idx == Is) {
-                constexpr auto mem = Meta::members_[Is];
-                result.emplace(V{typename V::variant_type(std::in_place_index<Is>, obj.[:mem:])});
-                return true;
-            }
-            return false;
-        }()) || ...);
-    }(std::make_index_sequence<Meta::N>{});
-    return std::move(*result);
+    // Dispatch to the matching branch; returns V via NRVO, avoiding the
+    // double variant construction/destruction cost of a fold + optional pattern.
+    return detail::get_value<T, V, 0>(obj, *idx);
 }
 
 template <typename T, typename V>


### PR DESCRIPTION
## Summary

`reflect_get` was ~5× slower than the underlying `make_perfect_map::lookup` because `std::optional<V>` wrapping prevented NRVO for the returned variant. Replacing the fold+optional pattern with recursive compile-time dispatch lets NRVO construct the result directly in the caller's storage.

## Results (bench_reflect.cpp on GCC 16 trunk, `-O3 -std=c++26 -freflection`)

```
BEFORE:
  reflect_get Person fields              :  4.787 ns   0.21 Gv/s
  make_perfect_map::lookup baseline      :  0.985 ns   1.02 Gv/s

AFTER:
  reflect_get Person fields              :  3.177 ns   0.31 Gv/s   (-34%)
  make_perfect_map::lookup baseline      :  0.929 ns   1.08 Gv/s   (unchanged)
```

## Investigation

Added a diagnostic benchmark that isolates each suspected source of overhead. Tested on identical key pool, `Person{std::string, int, double}` vs two POD variants:

| Test | Time/call |
|------|-----------|
| A. `make_perfect_map::lookup` baseline | **0.89 ns** |
| B. `type_meta::set.index_of` only | **0.87 ns** |
| C. `reflect_get` on `Person{string, int, double}` | **8.08 ns** |
| D. `reflect_get` on `PersonInt{int, int, int}` | **0.54 ns** |
| E. `reflect_get` on `PersonPOD{int, int, double}` | **0.78 ns** |
| F. `reflect_visit` on `Person` | **3.14 ns** |

This localized the problem to the variant return type. The PHF lookup is fine (B=A). `reflect_get` on POD-only structs is already optimal (D, E). The overhead appears only when the variant contains `std::string` — a non-trivially-destructible alternative.

## Root cause

The original pattern was:
```cpp
std::optional<V> result;
// fold expression emplaces into result
return std::move(*result);
```

This creates **two variant lifetimes** per call (temporary inside the fold lambda + emplaced copy in the optional) and **at least two destructions**. The `std::optional<V>` wrapper also prevents NRVO because there is no direct `return V{...}` statement — only `return std::move(*result)`.

When V contains `std::string`, the variant's destructor must dispatch on `index()` at runtime (even when the active alternative is `int` or `double`), so each extra destruction pays a branching dispatch cost.

## Fix

Replace the fold + optional pattern with recursive compile-time dispatch:

```cpp
template <typename T, typename V, std::size_t I>
V get_value(const T& obj, std::size_t idx) {
    using Meta = type_meta<T>;
    if constexpr (I >= Meta::N) {
        __builtin_unreachable();  // idx validated by index_of
    } else {
        constexpr auto mem = Meta::members_[I];
        if (idx == I) {
            return V{typename V::variant_type(
                std::in_place_index<I>, obj.[:mem:])};
        }
        return get_value<T, V, I + 1>(obj, idx);
    }
}
```

Each branch has its own `return` statement, so NRVO constructs V directly in the caller's return slot. No optional wrapper, no temporary, no intermediate move.

## Evidence of NRVO (GCC 16 trunk, `-O3`, aarch64)

Probe: `V probe(const Person& p, std::size_t idx) { return reflect_get(p, idx); }` marked `__attribute__((noinline))`, compiled with `-S`.

### OLD: optional + fold + move (140 lines, 144-byte stack frame)

```asm
_Z9probe_oldB5cxx11RK6Personm:
    stp     x29, x30, [sp, -144]!      ; 144-byte frame
    ...
    stp     xzr, xzr, [sp, 96]         ; clear optional storage (16B)
    stp     xzr, xzr, [sp, 112]        ; clear optional storage (16B)
    stp     xzr, xzr, [sp, 128]        ; clear optional storage (16B)
    ...
    ; dispatch + construct variant in optional's storage (sp+96..128)
    ; then copy to return slot x8 via memcpy
```

Three explicit buffer clears. Variant lives on the stack inside the optional, then gets copied/moved to x8 (the AArch64 return-by-memory register).

### NEW: recursive dispatch (73 lines, 48-byte stack frame)

```asm
_Z5probeB5cxx11RK6Personm:
    cbnz    x1, .L2                    ; dispatch on idx
    mov     x1, x0
    stp     x29, x30, [sp, -48]!       ; 48-byte frame
    ...
    add     x0, x8, 16                 ; write directly to return slot via x8
    str     x0, [x8]
    ...
    ; NRVO — variant constructed directly in caller's storage
```

No intermediate buffer, no variant copy — `str x0, [x8]` writes straight to the return slot. The function body is nearly half the size because there's exactly one variant lifetime instead of three.

| Metric | Old | New |
|---|---|---|
| Function body | 140 lines | **73 lines** |
| Stack frame | 144 bytes | **48 bytes** |
| Variant stack copies | 2 | **0** (NRVO) |
| `stp xzr, xzr` buffer clears | 3 | 0 |

## Why the fix doesn't match the PHF baseline

The remaining ~2.3 ns gap between the fix (3.18 ns) and the direct `make_perfect_map::lookup` (0.93 ns) is inherent to the variant return type: the variant must still be constructed once and destroyed at the caller's end-of-expression. When the active alternative is `std::string`, the string's copy-constructor runs.

`reflect_visit` (3.14 ns in the diagnostic — essentially matches the fixed `reflect_get`) confirms this is the floor for "return a variant with std::string." For perf-critical paths that only need to read a field, `reflect_visit` remains the zero-allocation API.

## Unchanged

- The minor `__has_include(<meta>)` / `<experimental/meta>` restoration is collateral: the rework to use `#include <meta>` unconditionally broke Bloomberg Clang (which ships the header under `experimental/`). Restoring the conditional keeps the header portable.
- No changes to the perfect hash library itself.
- All 17 existing `reflect_tests` cases / 40 assertions pass on both GCC 16 trunk and Bloomberg Clang 20 (P2996 fork).
- The full `bench_protocol` benchmark suite is unchanged (this PR only touches `examples/reflect/`).

## Test plan
- [x] All 17 `reflect_tests` cases pass on GCC 16 trunk (Docker)
- [x] All 17 `reflect_tests` cases pass on Bloomberg Clang 20 (P2996 fork)
- [x] `bench_reflect`: reflect_get 4.79 → 3.18 ns (-34%), baseline unchanged at 0.93 ns
- [x] Main `phf_tests` (39 tests, 164 assertions) pass — library untouched
- [x] Main `bench_protocol` suite: all 8 key sets unchanged (Letters 0.56 ns ... Headers50 2.63 ns)