### PR TITLE
another benchmark

### DIFF
--- a/benchmarks/bench_protocol.cpp
+++ b/benchmarks/bench_protocol.cpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <ankerl/unordered_dense.h>
 #include <absl/container/flat_hash_map.h>
@@ -36,7 +37,7 @@
 // Filter support: --filter hits,make_perfect_map,protocol
 //   Workloads: hits, misses, mixed
 //   Methods:   make_perfect_map, naive, unordered_map, ankerl, absl, frozen, kronuz, gperf, pthash
-//   Keysets:   protocol, stock, keyword, header, mime, jsreserved
+//   Keysets:   protocol, stock, keyword, header, mime, letters, headers50, jsreserved, counters
 // Omitting a category means "run all" for that category.
 // ============================================================================
 
@@ -60,7 +61,7 @@ BenchFilter parse_filter(const std::string &arg) {
   BenchFilter f;
   static const std::set<std::string> valid_workloads = {"hits", "misses", "mixed"};
   static const std::set<std::string> valid_methods = {"make_perfect_map", "naive", "unordered_map", "ankerl", "absl", "frozen", "kronuz", "gperf", "pthash"};
-  static const std::set<std::string> valid_keysets = {"protocol", "stock", "keyword", "header", "mime", "letters", "headers50", "jsreserved"};
+  static const std::set<std::string> valid_keysets = {"protocol", "stock", "keyword", "header", "mime", "letters", "headers50", "jsreserved", "counters"};
 
   size_t start = 0;
   while (start < arg.size()) {
@@ -1010,6 +1011,66 @@ auto gperf_jsreserved_fn = [](std::string_view s) -> std::optional<int> {
 };
 
 // ============================================================================
+// Key set 9: Counters (10 keys, snake_case telemetry fields)
+// ============================================================================
+
+static constexpr auto counters_phf =
+    ConstexprCore::make_perfect_map<
+        ConstexprCore::kv<"total_items", 0>,
+        ConstexprCore::kv<"successful_operations", 1>,
+        ConstexprCore::kv<"failed_operations", 2>,
+        ConstexprCore::kv<"warnings", 3>,
+        ConstexprCore::kv<"errors", 4>,
+        ConstexprCore::kv<"retries", 5>,
+        ConstexprCore::kv<"bytes_processed", 6>,
+        ConstexprCore::kv<"records_read", 7>,
+        ConstexprCore::kv<"records_matched", 8>,
+        ConstexprCore::kv<"records_written", 9>>();
+
+static constexpr frozen::unordered_map<frozen::string, int, 10> counters_frozen = {
+    {"total_items", 0}, {"successful_operations", 1}, {"failed_operations", 2},
+    {"warnings", 3}, {"errors", 4}, {"retries", 5},
+    {"bytes_processed", 6}, {"records_read", 7},
+    {"records_matched", 8}, {"records_written", 9}
+};
+
+static constexpr auto counters_kronuz = [] {
+  fnv1ah32 h{};
+  return phf::make_phf({
+    h("total_items"), h("successful_operations"), h("failed_operations"),
+    h("warnings"), h("errors"), h("retries"),
+    h("bytes_processed"), h("records_read"), h("records_matched"),
+    h("records_written")
+  });
+}();
+
+std::optional<int> counters_naive(std::string_view s) {
+  if (s == "total_items") return 0;
+  if (s == "successful_operations") return 1;
+  if (s == "failed_operations") return 2;
+  if (s == "warnings") return 3;
+  if (s == "errors") return 4;
+  if (s == "retries") return 5;
+  if (s == "bytes_processed") return 6;
+  if (s == "records_read") return 7;
+  if (s == "records_matched") return 8;
+  if (s == "records_written") return 9;
+  return std::nullopt;
+}
+
+// Keep gperf method available for this keyset without adding another generated gperf include.
+auto gperf_counters_fn = [](std::string_view s) -> std::optional<int> {
+  static const std::unordered_set<std::string_view> keys = {
+      "total_items", "successful_operations", "failed_operations",
+      "warnings", "errors", "retries", "bytes_processed",
+      "records_read", "records_matched", "records_written"};
+  if (keys.find(s) != keys.end()) {
+    return std::optional<int>(1);
+  }
+  return std::nullopt;
+};
+
+// ============================================================================
 // Verification
 // ============================================================================
 
@@ -1128,7 +1189,7 @@ int main(int argc, char *argv[]) {
       std::println("Filter tokens (mix and match):");
       std::println("  Workloads: hits, misses, mixed");
       std::println("  Methods:   make_perfect_map, naive, unordered_map, ankerl, absl, frozen, kronuz, gperf, pthash");
-      std::println("  Keysets:   protocol, stock, keyword, header, mime, letters, headers50, jsreserved\n");
+      std::println("  Keysets:   protocol, stock, keyword, header, mime, letters, headers50, jsreserved, counters\n");
       std::println("Omitting a category runs all values for that category.\n");
       std::println("Examples:");
       std::println("  {} --filter hits,make_perfect_map,protocol", argv[0]);
@@ -1247,6 +1308,11 @@ int main(int argc, char *argv[]) {
        "package","private","protected","public","static"},
       {"let","console","alert","document","window","Array","Object","String","Number","Boolean",
        "undefined","NaN","Infinity","Math","Date","RegExp","JSON","Promise","async","arguments"});
+    all_ok &= verify_keyset("Counters", counters_phf, counters_naive, counters_frozen, counters_kronuz, gperf_counters_fn,
+      {"total_items","successful_operations","failed_operations","warnings","errors",
+       "retries","bytes_processed","records_read","records_matched","records_written"},
+      {"records_validated","total_bytes","processed_bytes","failed_requests","invalid_records",
+       "total_records","matched_records","written_records","ok_count","error_count"});
     return all_ok ? 0 : 1;
   }
 
@@ -1354,6 +1420,16 @@ int main(int argc, char *argv[]) {
        "package","private","protected","public","static"},
       {"let","console","alert","document","window","Array","Object","String","Number","Boolean",
        "undefined","NaN","Infinity","Math","Date","RegExp","JSON","Promise","async","arguments"},
+      filter, describe);
+  }
+
+  // --- Counters (10 keys, snake_case telemetry fields) ---
+  if (filter.run_keyset("counters")) {
+    run_keyset("Counters", counters_phf, counters_naive, counters_frozen, counters_kronuz, gperf_counters_fn,
+      {"total_items","successful_operations","failed_operations","warnings","errors",
+       "retries","bytes_processed","records_read","records_matched","records_written"},
+      {"records_validated","total_bytes","processed_bytes","failed_requests","invalid_records",
+       "total_records","matched_records","written_records","ok_count","error_count"},
       filter, describe);
   }
 }


### PR DESCRIPTION
The new `counters` case is such that we end up having mispredicted branches. The reason for that is that the hash function tries to access the character at position 8, but not all strings have it. So it causes a misprediction. At least, that's the (credible) story that my AI told me.

```
./build/benchmarks/bench_protocol --filter ,counters,
Warning: unknown filter token ''

=== Counters (N=10, MaxKeyLen=21) ===
  --- all hits ---
  hits   make_perfect_map (gperf)                  :   6.688 ns   0.15 Gv/s  23.31 c  65.21 i  2.80 i/c  0.31 bm
  hits   naive                                     :  15.842 ns   0.06 Gv/s  55.26 c  99.69 i  1.80 i/c  0.94 bm
  hits   std::unordered_map                        :  18.423 ns   0.05 Gv/s  64.26 c  69.42 i  1.08 i/c  1.15 bm
  hits   ankerl::dense                             :  11.750 ns   0.09 Gv/s  40.98 c  92.78 i  2.26 i/c  0.61 bm
  hits   absl::flat_hash_map                       :  11.201 ns   0.09 Gv/s  39.06 c  130.59 i  3.34 i/c  0.51 bm
  hits   frozen::unordered_map                     :  22.253 ns   0.04 Gv/s  77.63 c  203.32 i  2.62 i/c  1.10 bm
  hits   kronuz::phf                               :  12.057 ns   0.08 Gv/s  42.02 c  109.20 i  2.60 i/c  0.90 bm
  hits   gperf                                     :  19.448 ns   0.05 Gv/s  67.83 c  75.02 i  1.11 i/c  1.19 bm
  hits   pthash                                    :  25.897 ns   0.04 Gv/s  90.32 c  181.18 i  2.01 i/c  1.01 bm
  --- all misses ---
  misses make_perfect_map (gperf)                  :   4.519 ns   0.22 Gv/s  15.79 c  64.40 i  4.08 i/c  0.10 bm
  misses naive                                     :  14.992 ns   0.07 Gv/s  52.27 c  122.58 i  2.35 i/c  0.52 bm
  misses std::unordered_map                        :  19.600 ns   0.05 Gv/s  68.37 c  109.65 i  1.60 i/c  0.86 bm
  misses ankerl::dense                             :   4.093 ns   0.24 Gv/s  14.30 c  65.12 i  4.56 i/c  0.10 bm
  misses absl::flat_hash_map                       :   7.838 ns   0.13 Gv/s  27.34 c  86.06 i  3.15 i/c  0.30 bm
  misses frozen::unordered_map                     :  15.709 ns   0.06 Gv/s  54.80 c  105.44 i  1.92 i/c  0.91 bm
  misses kronuz::phf                               :  10.324 ns   0.10 Gv/s  36.00 c  108.03 i  3.00 i/c  0.58 bm
  misses gperf                                     :  20.136 ns   0.05 Gv/s  70.21 c  117.45 i  1.67 i/c  0.87 bm
  misses pthash                                    :  25.791 ns   0.04 Gv/s  89.97 c  170.08 i  1.89 i/c  0.61 bm
  --- mixed (50/50) ---
  mixed  make_perfect_map (gperf)                  :  12.422 ns   0.08 Gv/s  43.18 c  64.80 i  1.50 i/c  0.62 bm
  mixed  naive                                     :  17.565 ns   0.06 Gv/s  61.26 c  111.04 i  1.81 i/c  0.97 bm
  mixed  std::unordered_map                        :  22.417 ns   0.04 Gv/s  78.20 c  89.55 i  1.15 i/c  1.25 bm
  mixed  ankerl::dense                             :  12.807 ns   0.08 Gv/s  44.64 c  78.95 i  1.77 i/c  0.67 bm
  mixed  absl::flat_hash_map                       :  15.928 ns   0.06 Gv/s  55.56 c  108.34 i  1.95 i/c  0.82 bm
  mixed  frozen::unordered_map                     :  24.060 ns   0.04 Gv/s  83.93 c  154.30 i  1.84 i/c  1.32 bm
  mixed  kronuz::phf                               :  18.675 ns   0.05 Gv/s  65.12 c  108.59 i  1.67 i/c  1.19 bm
  mixed  gperf                                     :  23.112 ns   0.04 Gv/s  80.62 c  96.25 i  1.19 i/c  1.28 bm
  mixed  pthash                                    :  25.826 ns   0.04 Gv/s  90.09 c  175.59 i  1.95 i/c  0.82 bm
```